### PR TITLE
Schema-aware overhaul: fix non-public schema export/restore + best-practices pass (0.4.0)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -7,59 +7,56 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  unit:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
-          pip install .[test]
-          pip install pytest
+          pip install -e ".[dev]"
 
-      - name: Start CockroachDB (latest)
+      - name: Run unit tests
+        run: pytest -ra -q -m "not integration"
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
         run: |
-          docker run -d \
-            --name crdb \
-            -p 26257:26257 \
-            -p 8080:8080 \
-            cockroachdb/cockroach:latest \
-            start-single-node --insecure
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
 
-      - name: Set CRDB_URL environment variable
+      - name: Start CockroachDB (single node)
+        run: |
+          docker run -d --name crdb -p 26257:26257 -p 8080:8080 \
+            cockroachdb/cockroach:latest-v25.4 start-single-node --insecure
+          for i in $(seq 1 30); do
+            if docker exec crdb ./cockroach sql --insecure -e "SELECT 1" >/dev/null 2>&1; then
+              echo "CockroachDB ready"; break
+            fi
+            echo "waiting for crdb..."; sleep 2
+          done
+
+      - name: Set CRDB_URL
         run: echo "CRDB_URL=cockroachdb://root@localhost:26257/defaultdb?sslmode=disable" >> $GITHUB_ENV
 
-      - name: Wait for DB to be ready
-        run: sleep 5
-
-      - name: Initialize test database
-        run: |
-          docker exec crdb ./cockroach sql --insecure --host=localhost -e "
-            USE defaultdb;
-            CREATE TABLE users (
-              id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-              name STRING
-            );
-            INSERT INTO users (name) VALUES
-              ('Alice'), ('Bob'), ('Virag'), ('Allen'), ('Andrew'), ('David');
-          "
-
-      - name: Build package
-        run: python -m build
-
-      - name: Install project
-        run: pip install .
-
-      - name: Run all tests
-        run: pytest -ra -q -m "not integration or integration"
-
-      - name: Check for log file
-        run: test -f logs/crdb_dump.log
+      - name: Run integration tests
+        run: pytest -ra -q -m integration

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,13 @@ dist/
 *.egg-info/
 __pycache__/
 venv/
+.venv/
+.pytest_cache/
+crdb_dump_output/
+tmp/
+resume.json
+resume/
+
+# cockroach single-node aux output
+heap_profiler/
+cockroach-data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## 0.4.0 (unreleased)
+
+### Breaking
+- Object naming is now three-part `database.schema.table` everywhere
+  (filenames, manifests, resume-log keys, and `--tables` input). Pre-0.4.0
+  two-part dumps are not compatible with the 0.4.0 loader.
+- `--tables` two-part input now means `schema.table` (database taken from
+  `--db`), not the legacy `database.table`.
+- Minimum supported Python is now 3.10.
+
+### Fixed
+- Export and restore now work for objects in non-`public` schemas
+  (the data exporter previously crashed on three-part names, and schema
+  export silently dropped the schema component).
+- Mixed-case and reserved-word identifiers are now correctly quoted.
+- `load` honors `--host`/`--port`/`--certs-dir` (the psycopg2 path previously
+  ignored them and only read `CRDB_URL`/localhost).
+- Schema export no longer duplicates DDL when the aggregate file already exists.
+- Schema load splitting handles semicolons inside string literals and
+  function bodies (via `sqlparse`).
+- Selective data export (`--tables`) resolves the database from `--db` instead
+  of misreading the first name segment as the database.
+- Replaced deprecated `datetime.utcnow()`.
+
+### Added
+- Native `SHOW CREATE ALL TYPES` / `SHOW CREATE ALL TABLES` for full-database
+  dumps (dependency-ordered, with foreign-key constraints validated post-load).
+- Centralized identifier model (`crdb_dump/utils/identifiers.py`) used across
+  all modules for naming and safe SQL quoting.
+- Regression tests for CockroachDB `VECTOR` data round-trips (SQL and CSV).
+
+### Changed
+- Dependencies upgraded to current GA releases (SQLAlchemy 2.0.51,
+  sqlalchemy-cockroachdb 2.0.4, click 8.4.2, PyYAML 6.0.3, psycopg2-binary
+  2.9.12, boto3 1.43.36, sqlparse 0.5.5).
+- Data chunk files renamed from `<table>_chunk_NNN.*` to
+  `<db.schema.table>_NNN.*`; manifests to `<db.schema.table>.manifest.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md — crdb-dump
+
+Guidance for AI assistants (and humans) working in this repository.
+
+## What this is
+
+A Click-based CLI to export and import CockroachDB schemas and data. Export uses
+SQLAlchemy (`cockroachdb://`); data import uses psycopg2 `COPY`.
+
+Commands: `crdb-dump export`, `crdb-dump load`, `crdb-dump version`.
+
+## Layout
+
+- `crdb_dump/cli.py` — Click entrypoint and option definitions.
+- `crdb_dump/export/schema.py` — DDL export (tables/views/sequences/types/permissions).
+- `crdb_dump/export/data.py` — chunked data export (CSV/SQL, gzip, ordering, S3, manifests).
+- `crdb_dump/loader/loader.py` — schema apply + resumable chunk `COPY` (parallel, validate, S3).
+- `crdb_dump/utils/` — `identifiers.py` (object naming/quoting), `db_connection.py`,
+  `common.py` (retry, literal encoding, localities), `s3.py`, `io.py`, `logging.py`,
+  `type_constants.py`.
+- `crdb_dump/verify/` — checksum + diff.
+- `tests/` — `test_unit.py` (no DB), `test_integration.py` (needs `CRDB_URL`).
+- `test-local.sh` — full end-to-end run against a live cluster + MinIO.
+
+## Core convention: three-part identifiers
+
+CockroachDB objects are `database.schema.table`. **Never** assume two-part
+`database.table`. All object naming and SQL identifier quoting goes through
+`crdb_dump/utils/identifiers.py`:
+
+- `parse_object_name(...)` to get an `ObjectName(database, schema, table)`.
+- `.fq_quoted()` → `"db"."schema"."table"` for SQL.
+- `.fq_plain()` → `db.schema.table` for filenames, manifests, resume-log keys, logs.
+
+Do not interpolate raw identifiers into SQL strings. Always quote via the helper —
+this is both a correctness fix (mixed-case/reserved/non-public names) and a safety fix.
+
+`--tables` input is interpreted as `db.schema.table` or `schema.table` (db defaults to
+`--db`). Two-part input means `schema.table`, not legacy `db.table`.
+
+## Schema DDL
+
+- Full-database export: `SHOW CREATE ALL TYPES` then `SHOW CREATE ALL TABLES`
+  (dependency-ordered, FK constraints split into trailing `ALTER ... VALIDATE`).
+- Selective export: per-object `SHOW CREATE <type> <fq_quoted>`.
+
+## Working rules (user preferences)
+
+- **Test before proposing a push.** Every change must have passing **unit +
+  integration + e2e** coverage. Run `pytest -m unit`, `pytest -m integration`
+  (with `CRDB_URL`), and `./test-local.sh` before asking to push.
+- **No bot commit messages.** Plain, human-style messages. No `Co-Authored-By`,
+  no "Generated with …" trailers.
+
+## Running
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+pip install -e ".[dev]"
+
+pytest -m unit
+pytest -m integration   # requires CRDB_URL + reachable cluster
+./test-local.sh         # full e2e (needs cockroach + docker/MinIO)
+```
+
+## Requirements
+
+Python >= 3.10.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,15 +40,19 @@ this is both a correctness fix (mixed-case/reserved/non-public names) and a safe
 
 ## Schema DDL
 
-- Full-database export: `SHOW CREATE ALL TYPES` then `SHOW CREATE ALL TABLES`
-  (dependency-ordered, FK constraints split into trailing `ALTER ... VALIDATE`).
+- Full-database export: `CREATE SCHEMA IF NOT EXISTS` for user schemas, then
+  `SHOW CREATE ALL TYPES`, then `SHOW CREATE ALL TABLES` (dependency-ordered, FK
+  constraints split into trailing `ALTER ... VALIDATE`).
 - Selective export: per-object `SHOW CREATE <type> <fq_quoted>`.
+- BYTES are encoded as bytea hex (`\x...`) in CSV so `COPY` restores them
+  correctly; in SQL they use `decode('...','hex')`.
 
 ## Working rules (user preferences)
 
 - **Test before proposing a push.** Every change must have passing **unit +
-  integration + e2e** coverage. Run `pytest -m unit`, `pytest -m integration`
-  (with `CRDB_URL`), and `./test-local.sh` before asking to push.
+  integration + e2e** coverage. Run `pytest -m "not integration"`,
+  `pytest -m integration` (with `CRDB_URL`), and `./test-local.sh` before
+  asking to push.
 - **No bot commit messages.** Plain, human-style messages. No `Co-Authored-By`,
   no "Generated with …" trailers.
 
@@ -58,7 +62,7 @@ this is both a correctness fix (mixed-case/reserved/non-public names) and a safe
 export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
 pip install -e ".[dev]"
 
-pytest -m unit
+pytest -m "not integration"
 pytest -m integration   # requires CRDB_URL + reachable cluster
 ./test-local.sh         # full e2e (needs cockroach + docker/MinIO)
 ```

--- a/README.md
+++ b/README.md
@@ -5,15 +5,30 @@
 
 # crdb-dump
 
-A feature-rich CLI for exporting and importing CockroachDB schemas and data. Includes support for parallel chunked exports, manifest checksums, BYTES/UUID/ARRAY types, permission introspection, secure resumable imports, S3-compatible storage (MinIO, Cohesity), region-aware filtering, and automatic retry logic.
+A feature-rich CLI for exporting and importing CockroachDB schemas and data. Includes support for parallel chunked exports, manifest checksums, BYTES/UUID/ARRAY/VECTOR types, multi-schema (non-`public`) objects, permission introspection, secure resumable imports, S3-compatible storage (MinIO, Cohesity), region-aware filtering, and automatic retry logic.
+
+> **Requires Python 3.10+.**
+
+> ### ⚠️ Breaking changes in 0.4.0
+> - All object names are now three-part `database.schema.table` (filenames,
+>   manifests, resume-log keys, and `--tables` input). Objects in non-`public`
+>   schemas are now exported and restored correctly.
+> - `--tables` two-part input means `schema.table` (database taken from `--db`),
+>   not the old `database.table`. Use `db.schema.table` to be explicit, or a bare
+>   `table` for the `public` schema.
+> - Data chunk files are now `db.schema.table_NNN.csv|sql`; manifests are
+>   `db.schema.table.manifest.json`. Pre-0.4.0 dumps are not compatible.
+>
+> See [CHANGELOG.md](CHANGELOG.md) for the full list.
 
 ---
 
 ## 🚀 Features
 
-* ✅ Schema export: tables, views, sequences, enums
+* ✅ Schema export: tables, views, sequences, enums (objects in any schema, not just `public`)
+* ✅ Full-database dumps use native `SHOW CREATE ALL TABLES`/`ALL TYPES` (dependency-ordered, FK constraints validated post-load)
 * ✅ Data export: CSV or SQL with chunking, gzip, and ordering
-* ✅ Types: handles BYTES, UUIDs, STRING\[], TIMESTAMP, enums
+* ✅ Types: handles BYTES, UUIDs, STRING\[], TIMESTAMP, enums, VECTOR
 * ✅ Schema output formats: `sql`, `json`, `yaml`
 * ✅ Resumable `COPY`-based imports with chunk-level tracking
 * ✅ Permission exports: roles, grants, role memberships
@@ -114,11 +129,11 @@ crdb-dump export \
 
 | Option                  | Description                                   |
 | ----------------------- | --------------------------------------------- |
-| `--per-table`           | One file per object (e.g., `table_users.sql`) |
+| `--per-table`           | One file per object (e.g., `table_mydb.public.users.sql`) |
 | `--format`              | Output format: `sql`, `json`, `yaml`          |
 | `--diff`                | Show schema diff vs previous `.sql` file      |
-| `--tables`              | Comma-separated FQ names to include           |
-| `--exclude-tables`      | Skip specific FQ table names                  |
+| `--tables`              | Comma-separated names to include: `table`, `schema.table`, or `db.schema.table` |
+| `--exclude-tables`      | Skip specific table names (same forms as `--tables`) |
 | `--include-permissions` | Export roles, grants, and memberships         |
 | `--region`              | Only export tables matching this region       |
 
@@ -239,9 +254,20 @@ crdb_dump_output/mydb/mydb_schema.diff
 
 ## 🧪 Testing
 
+Requires Python 3.10+.
+
 ```bash
-pytest -m unit
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+
+# Unit tests (no database needed)
+pytest -m "not integration"
+
+# Integration tests (need a reachable CockroachDB)
+export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
 pytest -m integration
+
+# Full end-to-end (needs cockroach + Docker/MinIO)
 ./test-local.sh
 ```
 

--- a/crdb_dump/export/data.py
+++ b/crdb_dump/export/data.py
@@ -11,6 +11,7 @@ from crdb_dump.export.schema import collect_objects
 from crdb_dump.utils.db_connection import get_sqlalchemy_engine
 from crdb_dump.utils.common import to_sql_literal, to_csv_literal
 from crdb_dump.utils.identifiers import parse_object_name, quote_ident
+from crdb_dump.utils.io import validate_fq_table_names
 
 
 def export_table_data(engine, table, out_dir, export_format, split, limit, compress, order, order_desc,
@@ -141,8 +142,11 @@ def export_data(opts, out_dir, logger):
         print(str(engine.url))
         return
 
-    table_list = opts['tables'].split(',') if opts['tables'] else []
-    if not table_list:
+    if opts['tables']:
+        # Normalize user-provided names (table / schema.table / db.schema.table)
+        # to three-part db.schema.table using --db as the default database.
+        table_list = validate_fq_table_names(opts['tables'].split(','), opts['db'])
+    else:
         table_list = collect_objects(engine, opts['db'], 'table', logger, retry_count, retry_delay)
 
     if region_filter:

--- a/crdb_dump/export/data.py
+++ b/crdb_dump/export/data.py
@@ -10,15 +10,19 @@ from sqlalchemy import text
 from crdb_dump.export.schema import collect_objects
 from crdb_dump.utils.db_connection import get_sqlalchemy_engine
 from crdb_dump.utils.common import to_sql_literal, to_csv_literal
+from crdb_dump.utils.identifiers import parse_object_name, quote_ident
 
 
 def export_table_data(engine, table, out_dir, export_format, split, limit, compress, order, order_desc,
                       chunk_size, order_strict, logger, locality_map, retry_count, retry_delay, opts):
     try:
-        db, tbl = table.split('.')
-        base_name = tbl.replace('.', '_')
+        obj = parse_object_name(table, default_db=table.split('.')[0])
+        base_name = obj.file_base()
         with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
-            cols_res = conn.execute(text(f"SELECT column_name FROM information_schema.columns WHERE table_name='{tbl}'"))
+            cols_res = conn.execute(text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = :t AND table_schema = :s ORDER BY ordinal_position"
+            ), {"t": obj.table, "s": obj.schema})
             columns = [row[0] for row in cols_res]
             if order:
                 for col in order.split(','):
@@ -50,7 +54,7 @@ def export_table_data(engine, table, out_dir, export_format, split, limit, compr
                 return h.hexdigest()
 
             while True:
-                query = f"SELECT * FROM {table} {order_clause} OFFSET {offset} LIMIT {batch_size}"
+                query = f"SELECT * FROM {obj.fq_quoted()} {order_clause} OFFSET {offset} LIMIT {batch_size}"
                 if limit and offset >= limit:
                     break
                 rows = conn.execute(text(query)).fetchall()
@@ -61,8 +65,10 @@ def export_table_data(engine, table, out_dir, export_format, split, limit, compr
 
                 out_path = os.path.join(
                     out_dir,
-                    f"{base_name}_chunk_{chunk_index:03d}.csv.gz" if compress else f"{base_name}_chunk_{chunk_index:03d}.csv"
-                ) if export_format == 'csv' else os.path.join(out_dir, f"{base_name}_chunk_{chunk_index:03d}_data.sql")
+                    f"{base_name}_{chunk_index:03d}.csv.gz" if compress
+                    else f"{base_name}_{chunk_index:03d}.csv"
+                ) if export_format == 'csv' else os.path.join(
+                    out_dir, f"{base_name}_{chunk_index:03d}.sql")
 
                 if export_format == 'csv':
                     open_func = gzip.open if compress else open
@@ -72,10 +78,11 @@ def export_table_data(engine, table, out_dir, export_format, split, limit, compr
                         writer.writerow(columns)
                         writer.writerows([[to_csv_literal(v) for v in row] for row in rows])
                 elif export_format == 'sql':
+                    col_list = ", ".join(quote_ident(c) for c in columns)
                     with open(out_path, 'w') as f:
                         for row in rows:
                             vals = ", ".join(to_sql_literal(v) for v in row)
-                            f.write(f"INSERT INTO {tbl} ({', '.join(columns)}) VALUES ({vals});\n")
+                            f.write(f"INSERT INTO {obj.fq_quoted()} ({col_list}) VALUES ({vals});\n")
 
                 checksum = file_checksum(out_path)
                 manifest.append({
@@ -105,7 +112,7 @@ def export_table_data(engine, table, out_dir, export_format, split, limit, compr
             region = locality_map.get(table, "N/A")
             with open(manifest_path, 'w') as mf:
                 json.dump({
-                    "table": table,
+                    "table": obj.fq_plain(),
                     "region": region,
                     "chunks": manifest
                 }, mf, indent=2)
@@ -165,7 +172,7 @@ def export_data(opts, out_dir, logger):
     else:
         results = [wrapped_export(*args) for args in data_tasks]
 
-    table_row_counts = {tbl.split('.')[-1]: count for tbl, count in zip([t[1] for t in data_tasks], results)}
+    table_row_counts = {t[1]: count for t, count in zip(data_tasks, results)}
     total_rows = sum(table_row_counts.values())
 
     for table, count in table_row_counts.items():

--- a/crdb_dump/export/schema.py
+++ b/crdb_dump/export/schema.py
@@ -8,6 +8,7 @@ from sqlalchemy import text
 from crdb_dump.utils.db_connection import get_sqlalchemy_engine
 from crdb_dump.utils.common import to_json_literal, get_table_locality
 from crdb_dump.utils.io import write_file, archive_output, normalize_filename, validate_fq_table_names
+from crdb_dump.utils.identifiers import quote_ident
 
 def dump_create_statement(engine, obj_type, full_name, logger, retry_count, retry_delay):
     try:
@@ -41,28 +42,35 @@ def dump_create_statement(engine, obj_type, full_name, logger, retry_count, retr
         return None
 
 def collect_objects(engine, db, obj_type, logger, retry_count, retry_delay):
+    # SHOW TABLES/SEQUENCES/TYPES expose (schema, name, ...) in columns 0 and 1.
     query_map = {
         'table': "SHOW TABLES",
-        'view': "SELECT table_name FROM information_schema.views WHERE table_schema NOT IN ('pg_catalog', 'information_schema')",
+        'view': ("SELECT table_schema, table_name FROM information_schema.views "
+                 "WHERE table_schema NOT IN ('pg_catalog', 'information_schema', 'crdb_internal')"),
         'sequence': "SHOW SEQUENCES",
-        'type': "SHOW TYPES"
+        'type': "SHOW TYPES",
     }
     objs = []
     try:
         with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
-            conn.execute(text(f"USE {db}"))
+            conn.execute(text(f"USE {quote_ident(db)}"))
             result = conn.execute(text(query_map[obj_type]))
             for row in result:
-                name = row[0] if obj_type == 'view' else row[1] if obj_type in ['table', 'sequence', 'type'] else None
-                if name:
-                    if obj_type == 'type':
-                        enum_check = conn.execute(
-                            text(f"SELECT * FROM pg_type WHERE typname = '{name}' AND typtype = 'e'")
-                        ).fetchall()
-                        if not enum_check:
-                            logger.warning(f"Skipping non-enum type: {name}")
-                            continue
-                    objs.append(f"{db}.{name}")
+                if obj_type in ('view', 'table', 'sequence', 'type'):
+                    schema, name = row[0], row[1]
+                else:
+                    continue
+                if not name:
+                    continue
+                if obj_type == 'type':
+                    enum_check = conn.execute(
+                        text("SELECT 1 FROM pg_type WHERE typname = :n AND typtype = 'e'"),
+                        {"n": name},
+                    ).fetchall()
+                    if not enum_check:
+                        logger.warning(f"Skipping non-enum type: {schema}.{name}")
+                        continue
+                objs.append(f"{db}.{schema}.{name}")
     except Exception as e:
         logger.error(f"Error fetching {obj_type}s: {e}")
     return objs

--- a/crdb_dump/export/schema.py
+++ b/crdb_dump/export/schema.py
@@ -1,41 +1,67 @@
 import json
 import os
+import click
 import yaml
 from crdb_dump.utils.common import retry
-from datetime import datetime
+from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor
 from sqlalchemy import text
 from crdb_dump.utils.db_connection import get_sqlalchemy_engine
 from crdb_dump.utils.common import to_json_literal, get_table_locality
 from crdb_dump.utils.io import write_file, archive_output, normalize_filename, validate_fq_table_names
-from crdb_dump.utils.identifiers import quote_ident
+from crdb_dump.utils.identifiers import ObjectName, parse_object_name, quote_ident
+
+def dump_all_ddl(engine, db, logger, retry_count, retry_delay):
+    """Return full-database DDL via native bulk SHOW CREATE statements.
+
+    Emits ``SHOW CREATE ALL TYPES`` first (enums), then ``SHOW CREATE ALL TABLES``
+    which CockroachDB returns dependency-ordered (sequences -> tables -> views) with
+    foreign-key constraints split into trailing ALTER ... ADD CONSTRAINT ... VALIDATE.
+    """
+    parts = []
+    with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
+        conn.execute(text(f"USE {quote_ident(db)}"))
+        try:
+            types = conn.execute(text("SHOW CREATE ALL TYPES"))
+            for row in types:
+                stmt = row[0]
+                if stmt and stmt.strip():
+                    parts.append(stmt.rstrip().rstrip(";") + ";")
+        except Exception as e:
+            logger.warning(f"⚠️ SHOW CREATE ALL TYPES failed: {e}")
+        tables = conn.execute(text("SHOW CREATE ALL TABLES"))
+        for row in tables:
+            stmt = row[0]
+            if stmt and stmt.strip():
+                parts.append(stmt.rstrip().rstrip(";") + ";")
+    return "\n".join(parts) + ("\n" if parts else "")
+
 
 def dump_create_statement(engine, obj_type, full_name, logger, retry_count, retry_delay):
+    obj = parse_object_name(full_name, default_db=full_name.split('.')[0])
     try:
-        db = full_name.split('.')[0]
-        short_name = full_name.split('.')[-1]
         with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
-            conn.execute(text(f"USE {db}"))
+            conn.execute(text(f"USE {quote_ident(obj.database)}"))
             if obj_type == "TYPE":
                 result = conn.execute(text("SHOW CREATE ALL TYPES"))
                 matches = [
                     row[0] for row in result
-                    if row[0].startswith("CREATE TYPE") and f".{short_name} " in row[0]
+                    if row[0] and row[0].startswith("CREATE TYPE") and f".{obj.table} " in row[0]
                 ]
                 if matches:
-                    return matches[0] + ";\n"
-                if not short_name.startswith("crdb_internal"):
-                    logger.warning(f"Type {short_name} not found in SHOW CREATE ALL TYPES output")
+                    return matches[0].rstrip().rstrip(";") + ";\n"
+                if not obj.table.startswith("crdb_internal"):
+                    logger.warning(f"Type {obj.fq_plain()} not found in SHOW CREATE ALL TYPES output")
                 else:
-                    logger.info(f"Skipping internal type: {short_name}")
+                    logger.info(f"Skipping internal type: {obj.fq_plain()}")
                 return None
             else:
-                result = conn.execute(text(f"SHOW CREATE {obj_type} {short_name}"))
+                result = conn.execute(text(f"SHOW CREATE {obj_type} {obj.fq_quoted()}"))
                 rows = list(result)
                 if rows and len(rows[0]) > 1:
-                    return rows[0][1] + ";\n"
+                    return rows[0][1].rstrip().rstrip(";") + ";\n"
                 else:
-                    logger.warning(f"No DDL returned for {obj_type} {full_name}")
+                    logger.warning(f"No DDL returned for {obj_type} {obj.fq_plain()}")
                     return None
     except Exception as e:
         logger.error(f"Failed to get DDL for {obj_type} {full_name}: {e}")
@@ -78,58 +104,54 @@ def collect_objects(engine, db, obj_type, logger, retry_count, retry_delay):
 def resolve_object_types(engine, object_names, logger, retry_count, retry_delay):
     mapping = {}
     with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
-        for obj in object_names:
-            db, name = obj.split('.')
+        for obj_str in object_names:
+            obj = parse_object_name(obj_str, default_db=obj_str.split('.')[0])
+            conn.execute(text(f"USE {quote_ident(obj.database)}"))
             kind = None
 
             try:
-                # Check TABLE
                 res = conn.execute(text(
-                    f"SELECT table_name FROM information_schema.tables "
-                    f"WHERE table_schema = 'public' AND table_name = :name"
-                ), {"name": name}).fetchone()
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = :s AND table_name = :n"
+                ), {"s": obj.schema, "n": obj.table}).fetchone()
                 if res:
                     kind = "TABLE"
             except Exception as e:
-                logger.debug(f"Error checking table for {obj}: {e}")
+                logger.debug(f"Error checking table for {obj.fq_plain()}: {e}")
 
             if not kind:
                 try:
-                    # Check VIEW
                     res = conn.execute(text(
-                        f"SELECT table_name FROM information_schema.views "
-                        f"WHERE table_schema = 'public' AND table_name = :name"
-                    ), {"name": name}).fetchone()
+                        "SELECT 1 FROM information_schema.views "
+                        "WHERE table_schema = :s AND table_name = :n"
+                    ), {"s": obj.schema, "n": obj.table}).fetchone()
                     if res:
                         kind = "VIEW"
-                except:
+                except Exception:
                     pass
 
             if not kind:
                 try:
-                    # Check TYPE
                     res = conn.execute(text(
-                        f"SELECT typname FROM pg_type WHERE typname = :name"
-                    ), {"name": name}).fetchone()
+                        "SELECT 1 FROM pg_type WHERE typname = :n"
+                    ), {"n": obj.table}).fetchone()
                     if res:
                         kind = "TYPE"
-                except:
+                except Exception:
                     pass
 
             if not kind:
                 try:
-                    # Check SEQUENCE
-                    res = conn.execute(text(f"SHOW SEQUENCES")).fetchall()
-                    seqs = [row[1] for row in res]  # db.schema.name format
-                    if name in [s.split('.')[-1] for s in seqs]:
+                    res = conn.execute(text("SHOW SEQUENCES")).fetchall()
+                    if obj.table in [row[1] for row in res]:
                         kind = "SEQUENCE"
-                except:
+                except Exception:
                     pass
 
             if kind:
-                mapping[obj] = kind
+                mapping[obj.fq_plain()] = kind
             else:
-                logger.warning(f"⚠️ Could not determine type of object: {obj}")
+                logger.warning(f"⚠️ Could not determine type of object: {obj.fq_plain()}")
 
     return mapping
 
@@ -151,37 +173,42 @@ def export_schema(opts, out_dir, logger):
     region_filter = opts.get("region")
     locality_map = get_table_locality(engine, db, logger)
 
-    # Wrap retry around critical functions
-    wrapped_dump_create = lambda *args: dump_create_statement(*args, retry_count, retry_delay)
-    wrapped_collect_objects = lambda *args: collect_objects(*args, retry_count, retry_delay)
-    wrapped_resolve_types = lambda *args: resolve_object_types(*args, retry_count, retry_delay)
-    wrapped_dump_permissions = lambda *args: dump_permissions(*args, retry_count, retry_delay)
-
     if include and exclude:
         raise click.UsageError("You cannot use --tables and --exclude-tables at the same time.")
 
+    aggregate_file = f"{out_dir}/{db}_schema.sql"
+
+    # Full-database, unfiltered, single-file SQL output -> native bulk DDL,
+    # which CockroachDB returns in dependency order with FK constraints validated.
+    if not include and not exclude and not region_filter and out_format == "sql" and not per_table:
+        ddl = dump_all_ddl(engine, db, logger, retry_count, retry_delay)
+        write_file(aggregate_file, ddl)
+        logger.info(f"Wrote: {aggregate_file}")
+        if opts.get("include_permissions"):
+            dump_permissions(engine, out_dir, logger, retry_count, retry_delay)
+        return
+
+    # Selective / per-table / json / yaml path (per-object SHOW CREATE).
     if include:
         tables_fq = validate_fq_table_names(include.split(','), db)
-        object_map = wrapped_resolve_types(engine, tables_fq, logger)
-        all_objects = [(typ, fqname) for fqname, typ in object_map.items()]
+        object_map = resolve_object_types(engine, tables_fq, logger, retry_count, retry_delay)
+        all_objects = [(typ, name) for name, typ in object_map.items()]
     else:
-        tables = wrapped_collect_objects(engine, db, 'table', logger)
-        views = wrapped_collect_objects(engine, db, 'view', logger)
-        sequences = wrapped_collect_objects(engine, db, 'sequence', logger)
-        types = wrapped_collect_objects(engine, db, 'type', logger)
+        tables = collect_objects(engine, db, 'table', logger, retry_count, retry_delay)
+        views = collect_objects(engine, db, 'view', logger, retry_count, retry_delay)
+        sequences = collect_objects(engine, db, 'sequence', logger, retry_count, retry_delay)
+        types = collect_objects(engine, db, 'type', logger, retry_count, retry_delay)
 
-        all_objects = [("TABLE", name) for name in tables] + \
-                      [("VIEW", name) for name in views] + \
+        # Dependency-friendly order: types -> sequences -> tables -> views.
+        all_objects = [("TYPE", name) for name in types] + \
                       [("SEQUENCE", name) for name in sequences] + \
-                      [("TYPE", name) for name in types]
+                      [("TABLE", name) for name in tables] + \
+                      [("VIEW", name) for name in views]
 
         if region_filter:
-            def region_matches(fqname):
-                loc = locality_map.get(fqname, "").upper()
-                return region_filter.upper() in loc
-
             before = len(all_objects)
-            all_objects = [obj for obj in all_objects if region_matches(obj[1])]
+            all_objects = [obj for obj in all_objects
+                           if region_filter.upper() in locality_map.get(obj[1], "").upper()]
             logger.info(f"📍 Region filter: {region_filter} — selected {len(all_objects)}/{before} objects")
 
         if exclude:
@@ -189,27 +216,29 @@ def export_schema(opts, out_dir, logger):
             all_objects = [obj for obj in all_objects if obj[1] not in exclude_set]
 
     if opts.get("include_permissions"):
-        wrapped_dump_permissions(engine, out_dir, logger)
+        dump_permissions(engine, out_dir, logger, retry_count, retry_delay)
+
+    # Truncate the aggregate file once before appending per-object DDL.
+    if not per_table and out_format == "sql":
+        write_file(aggregate_file, "")
 
     dump_data = []
 
     def process(obj_type, full_name):
-        ddl = wrapped_dump_create(engine, obj_type, full_name, logger)
+        ddl = dump_create_statement(engine, obj_type, full_name, logger, retry_count, retry_delay)
         if not ddl:
-            return  # ✅ Skip entirely if no DDL returned
+            return  # Skip entirely if no DDL returned
 
-        entry = {"name": full_name, "type": obj_type, "ddl": ddl.strip()}
-        dump_data.append(entry)
+        dump_data.append({"name": full_name, "type": obj_type, "ddl": ddl.strip()})
 
         if per_table and out_format == "sql":
-            filename = f"{out_dir}/{obj_type.lower()}_{full_name.split('.')[-1]}.sql"
+            filename = f"{out_dir}/{obj_type.lower()}_{full_name}.sql"
             write_file(filename, f"-- {obj_type}: {full_name}\n{ddl}\n")
             logger.info(f"Wrote: {filename}")
         elif not per_table and out_format == "sql":
-            filename = f"{out_dir}/{db}_schema.sql"
-            with open(filename, "a") as f:
+            with open(aggregate_file, "a") as f:
                 f.write(f"-- {obj_type}: {full_name}\n{ddl}\n\n")
-            logger.info(f"Wrote: {filename}")
+            logger.info(f"Appended {full_name} to {aggregate_file}")
 
     if parallel:
         with ThreadPoolExecutor() as executor:
@@ -276,7 +305,7 @@ def dump_permissions(engine, out_dir, logger, retry_count, retry_delay):
 
         # Aggregate file
         all_lines = [
-            f"-- Exported at: {datetime.utcnow().isoformat()} UTC",
+            f"-- Exported at: {datetime.now(timezone.utc).isoformat()} UTC",
             "-- ROLES --",
             *roles,
             "",

--- a/crdb_dump/export/schema.py
+++ b/crdb_dump/export/schema.py
@@ -19,8 +19,17 @@ def dump_all_ddl(engine, db, logger, retry_count, retry_delay):
     foreign-key constraints split into trailing ALTER ... ADD CONSTRAINT ... VALIDATE.
     """
     parts = []
+    system_schemas = {"public", "crdb_internal", "information_schema", "pg_catalog", "pg_extension"}
     with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
         conn.execute(text(f"USE {quote_ident(db)}"))
+        try:
+            schemas = conn.execute(text("SHOW SCHEMAS"))
+            for row in schemas:
+                schema_name = row[0]
+                if schema_name not in system_schemas:
+                    parts.append(f"CREATE SCHEMA IF NOT EXISTS {quote_ident(schema_name)};")
+        except Exception as e:
+            logger.warning(f"⚠️ SHOW SCHEMAS failed: {e}")
         try:
             types = conn.execute(text("SHOW CREATE ALL TYPES"))
             for row in types:

--- a/crdb_dump/loader/loader.py
+++ b/crdb_dump/loader/loader.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from sqlalchemy import text
 from crdb_dump.utils.common import retry
 from crdb_dump.utils.db_connection import get_psycopg_connection
+from crdb_dump.utils.identifiers import parse_object_name
 from crdb_dump.utils.s3 import get_s3_client, download_file_from_s3
 
 
@@ -29,10 +30,14 @@ def load_schema(schema_path, engine, logger):
         return False
 
 
-def validate_csv_header(table, filepath, logger):
-    conn = get_psycopg_connection()
+def validate_csv_header(table, filepath, logger, opts=None):
+    obj = parse_object_name(table, default_db=table.split('.')[0])
+    conn = get_psycopg_connection(opts)
     with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
-        cur.execute("SELECT column_name FROM information_schema.columns WHERE table_name = %s ORDER BY ordinal_position", (table.split('.')[-1],))
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = %s AND table_schema = %s ORDER BY ordinal_position",
+            (obj.table, obj.schema))
         db_columns = [row[0] for row in cur.fetchall()]
 
     with open(filepath, 'r') as f:
@@ -60,14 +65,15 @@ def load_chunk(table, file_path, engine, logger, validate=False, opts=None):
             download_file_from_s3(s3, opts["s3_bucket"], s3_key, local_path)
             logger.info(f"☁️ Downloaded from S3: s3://{opts['s3_bucket']}/{s3_key}")
 
-        if validate and not validate_csv_header(table, local_path, logger):
+        if validate and not validate_csv_header(table, local_path, logger, opts):
             logger.error(f"Skipping load for {file_path} due to header mismatch.")
             return False
 
-        conn = get_psycopg_connection()
+        obj = parse_object_name(table, default_db=table.split('.')[0])
+        conn = get_psycopg_connection(opts)
         with conn.cursor() as cur:
             with open(local_path, "r") as f:
-                sql = f"COPY {table} FROM STDIN WITH CSV HEADER"
+                sql = f"COPY {obj.fq_quoted()} FROM STDIN WITH CSV HEADER"
                 cur.copy_expert(sql, f)
         conn.commit()
         conn.close()

--- a/crdb_dump/loader/loader.py
+++ b/crdb_dump/loader/loader.py
@@ -2,12 +2,24 @@ import csv
 import json
 import os
 import psycopg2.extras
+import sqlparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from sqlalchemy import text
 from crdb_dump.utils.common import retry
 from crdb_dump.utils.db_connection import get_psycopg_connection
 from crdb_dump.utils.identifiers import parse_object_name
 from crdb_dump.utils.s3 import get_s3_client, download_file_from_s3
+
+
+def _split_sql_statements(sql):
+    """Split a SQL script into individual statements.
+
+    Uses sqlparse so semicolons inside string literals, UDF bodies, and
+    dollar-quoted blocks do not split a statement incorrectly.
+    """
+    return [s.strip().rstrip(";").strip()
+            for s in sqlparse.split(sql)
+            if s.strip().rstrip(";").strip()]
 
 
 def load_schema(schema_path, engine, logger):
@@ -17,7 +29,7 @@ def load_schema(schema_path, engine, logger):
 
     with open(schema_path) as f:
         sql = f.read()
-    statements = [stmt.strip() for stmt in sql.split(';') if stmt.strip()]
+    statements = _split_sql_statements(sql)
 
     try:
         with engine.begin() as conn:

--- a/crdb_dump/utils/common.py
+++ b/crdb_dump/utils/common.py
@@ -159,18 +159,20 @@ def get_type_and_args(col_type_and_args: list):
     raise ValueError(f"Unsupported type: {datatype}")
 
 def get_table_locality(engine, db, logger):
-    """Returns a dict mapping fq_table_name => locality string (or 'N/A')."""
+    """Returns a dict mapping db.schema.table => locality string (or 'N/A')."""
+    from crdb_dump.utils.identifiers import quote_ident
     mapping = {}
     try:
         with engine.connect() as conn:
-            conn.execute(text(f"USE {db}"))
-            result = conn.execute(text(f"SHOW TABLES FROM {db}"))
+            conn.execute(text(f"USE {quote_ident(db)}"))
+            result = conn.execute(text("SHOW TABLES"))
 
             for row in result:
                 # Expect: schema_name, table_name, type, owner, estimated_row_count, locality
+                schema_name = row[0]
                 table_name = row[1]
                 locality = row[5] if len(row) > 5 else "N/A"
-                fqname = f"{db}.{table_name}"
+                fqname = f"{db}.{schema_name}.{table_name}"
                 mapping[fqname] = locality or "N/A"
     except Exception as e:
         logger.warning(f"⚠️ Failed to retrieve table localities: {e}")

--- a/crdb_dump/utils/common.py
+++ b/crdb_dump/utils/common.py
@@ -59,10 +59,12 @@ def to_sql_literal(val):
     return str(val)
 
 def to_csv_literal(val):
+    # BYTES must use the bytea hex format ('\x' prefix) so COPY ... WITH CSV
+    # decodes them back to bytes instead of storing the literal hex characters.
     if isinstance(val, memoryview):
-        return val.tobytes().hex()
+        return r'\x' + val.tobytes().hex()
     if isinstance(val, (bytes, bytearray)):
-        return val.hex()
+        return r'\x' + val.hex()
     if isinstance(val, list):
         def escape_csv_array_item(item):
             if item is None:

--- a/crdb_dump/utils/db_connection.py
+++ b/crdb_dump/utils/db_connection.py
@@ -28,9 +28,24 @@ def get_sqlalchemy_engine(opts=None):
     return create_engine(base)
 
 
-def get_psycopg_connection():
+def get_psycopg_connection(opts=None):
     url = os.getenv("CRDB_URL")
-    if not url:
-        url = "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
-    pg_url = url.replace("cockroachdb://", "postgresql://")
-    return psycopg2.connect(pg_url)
+    if url:
+        pg_url = url.replace("cockroachdb://", "postgresql://", 1)
+        return psycopg2.connect(pg_url)
+
+    opts = opts or {}
+    host = opts.get("host", "localhost")
+    port = opts.get("port", 26257)
+    db = opts.get("db", "defaultdb")
+    base = f"postgresql://root@{host}:{port}/{db}"
+    if opts.get("certs_dir"):
+        base += (
+            f"?sslmode=verify-full"
+            f"&sslrootcert={opts['certs_dir']}/ca.crt"
+            f"&sslcert={opts['certs_dir']}/client.root.crt"
+            f"&sslkey={opts['certs_dir']}/client.root.key"
+        )
+    else:
+        base += "?sslmode=disable"
+    return psycopg2.connect(base)

--- a/crdb_dump/utils/identifiers.py
+++ b/crdb_dump/utils/identifiers.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+
+def quote_ident(name: str) -> str:
+    """Quote a single SQL identifier for CockroachDB/Postgres."""
+    return '"' + name.replace('"', '""') + '"'
+
+
+@dataclass(frozen=True)
+class ObjectName:
+    database: str
+    schema: str
+    table: str
+
+    def fq_quoted(self) -> str:
+        return ".".join(quote_ident(p) for p in (self.database, self.schema, self.table))
+
+    def fq_plain(self) -> str:
+        return f"{self.database}.{self.schema}.{self.table}"
+
+    def file_base(self) -> str:
+        return self.fq_plain()
+
+
+def parse_object_name(s: str, default_db: str, default_schema: str = "public") -> ObjectName:
+    """Parse a user/DB-supplied object name into a three-part ObjectName.
+
+    Accepts ``table`` (schema defaults to ``default_schema``), ``schema.table``
+    (database defaults to ``default_db``), or ``database.schema.table``.
+    Two-part input is treated as ``schema.table``, never legacy ``database.table``.
+    """
+    parts = s.split(".")
+    if len(parts) == 1:
+        return ObjectName(default_db, default_schema, parts[0])
+    if len(parts) == 2:
+        return ObjectName(default_db, parts[0], parts[1])
+    if len(parts) == 3:
+        return ObjectName(parts[0], parts[1], parts[2])
+    raise ValueError(f"Invalid object name '{s}': expected 1, 2, or 3 dot-separated parts")

--- a/crdb_dump/utils/io.py
+++ b/crdb_dump/utils/io.py
@@ -1,9 +1,8 @@
 import os
 import tarfile
-import os
-import re
 import logging
 
+from crdb_dump.utils.identifiers import parse_object_name
 
 
 logger = logging.getLogger(__name__)
@@ -20,15 +19,20 @@ def archive_output(directory):
     logger.info(f"Archived output to {archive_name}")
 
 def validate_fq_table_names(tables, db):
+    """Normalize table names to three-part ``db.schema.table`` strings.
+
+    Accepts ``table``, ``schema.table``, or ``db.schema.table`` input. A bare
+    table defaults to the ``public`` schema; a two-part name is ``schema.table``.
+    Raises if an explicit database prefix does not match ``db``.
+    """
+    out = []
     for t in tables:
-        if '.' not in t:
-            raise ValueError(f"❌ Invalid table name '{t}': must be fully-qualified like '{db}.users'")
-        parts = t.split('.')
-        if len(parts) != 2 or parts[0] != db:
-            raise ValueError(f"❌ Invalid table name '{t}': expected database prefix '{db}.'")
-    return tables
+        obj = parse_object_name(t, default_db=db)
+        if obj.database != db:
+            raise ValueError(
+                f"❌ Invalid table name '{t}': database '{obj.database}' does not match --db '{db}'")
+        out.append(obj.fq_plain())
+    return out
 
 def normalize_filename(obj_type, full_name):
-    _, name = full_name.split('.', 1)
-    safe_name = re.sub(r'[^\w]+', '_', name).lower()
-    return f"{obj_type.lower()}_{safe_name}.sql"
+    return f"{obj_type.lower()}_{full_name}.sql"

--- a/crdb_dump/verify/checksum.py
+++ b/crdb_dump/verify/checksum.py
@@ -18,8 +18,9 @@ def verify_checksums(opts, out_dir, logger):
     passed = 0
     missing = 0
 
+    from crdb_dump.utils.identifiers import parse_object_name
     for table in table_list:
-        base_name = table.split('.')[-1]
+        base_name = parse_object_name(table, default_db=opts['db']).file_base()
         manifest_path = os.path.join(out_dir, f"{base_name}.manifest.json")
         if not os.path.exists(manifest_path):
             logger.warning(f"No manifest found for {base_name}")

--- a/docs/superpowers/plans/2026-06-26-schema-aware-overhaul.md
+++ b/docs/superpowers/plans/2026-06-26-schema-aware-overhaul.md
@@ -1,0 +1,1245 @@
+# Schema-Aware Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `crdb-dump` export and restore correct for objects in any CockroachDB schema (not just `public`), and bring the project to current best practices.
+
+**Architecture:** Introduce one canonical identifier model (`ObjectName` + quoting) that every module uses for naming/qualification/quoting. Rewrite schema export to use native `SHOW CREATE ALL TYPES`/`SHOW CREATE ALL TABLES` for full dumps and schema-aware per-object `SHOW CREATE` for selective dumps. Make data export, the loader, and the connection layer fully three-part aware. Clean break to `database.schema.table` naming for files/manifests.
+
+**Tech Stack:** Python ≥3.10, Click, SQLAlchemy + sqlalchemy-cockroachdb, psycopg2, sqlparse, boto3, pytest.
+
+## Global Constraints
+
+- Python requirement: `requires-python = ">=3.10"`; classifiers 3.10–3.13 only.
+- Package version: `0.4.0`.
+- All SQL identifiers MUST be produced via `crdb_dump/utils/identifiers.py` — never raw f-string interpolation of names.
+- Object naming everywhere is three-part `database.schema.table`. No legacy two-part `database.table`.
+- New dependency allowed: `sqlparse`. No other new runtime deps without noting it.
+- Tests: every change needs passing unit + integration; full e2e (`test-local.sh`) must be green before proposing a push.
+- Commit messages: plain, human-style. No AI/bot attribution or trailers.
+
+---
+
+## Task 0: Dev environment + branch baseline
+
+**Files:**
+- Modify: `pyproject.toml` (dev extras only in this task)
+
+- [ ] **Step 1: Create venv and install editable with dev extras**
+
+Run:
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+python -m pip install -U pip
+pip install -e . pytest sqlparse
+```
+Expected: install succeeds. (We formalize `[dev]` extras in Task 9.)
+
+- [ ] **Step 2: Run existing unit tests as a baseline**
+
+Run: `python -m pytest -m unit -q`
+Expected: existing tests pass (or note pre-existing failures).
+
+- [ ] **Step 3: Commit nothing yet** — baseline only.
+
+---
+
+## Task 1: Identifier model (`identifiers.py`)
+
+**Files:**
+- Create: `crdb_dump/utils/identifiers.py`
+- Test: `tests/test_identifiers.py`
+
+**Interfaces:**
+- Produces:
+  - `class ObjectName` with fields `database: str, schema: str, table: str`
+    and methods `fq_quoted() -> str`, `fq_plain() -> str`, `file_base() -> str`.
+  - `quote_ident(name: str) -> str`
+  - `parse_object_name(s: str, default_db: str, default_schema: str = "public") -> ObjectName`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_identifiers.py
+import pytest
+from crdb_dump.utils.identifiers import ObjectName, quote_ident, parse_object_name
+
+
+def test_quote_ident_simple():
+    assert quote_ident("users") == '"users"'
+
+def test_quote_ident_escapes_embedded_quote():
+    assert quote_ident('we"ird') == '"we""ird"'
+
+def test_quote_ident_mixed_case_preserved():
+    assert quote_ident("MyTable") == '"MyTable"'
+
+def test_parse_three_part():
+    o = parse_object_name("cp.cpkit.tasks", default_db="ignored")
+    assert (o.database, o.schema, o.table) == ("cp", "cpkit", "tasks")
+
+def test_parse_two_part_is_schema_table():
+    o = parse_object_name("cpkit.tasks", default_db="cp")
+    assert (o.database, o.schema, o.table) == ("cp", "cpkit", "tasks")
+
+def test_parse_one_part_defaults_public():
+    o = parse_object_name("tasks", default_db="cp")
+    assert (o.database, o.schema, o.table) == ("cp", "public", "tasks")
+
+def test_fq_quoted():
+    o = ObjectName("cp", "cpkit", "tasks")
+    assert o.fq_quoted() == '"cp"."cpkit"."tasks"'
+
+def test_fq_plain_and_file_base():
+    o = ObjectName("cp", "cpkit", "tasks")
+    assert o.fq_plain() == "cp.cpkit.tasks"
+    assert o.file_base() == "cp.cpkit.tasks"
+
+def test_parse_rejects_four_parts():
+    with pytest.raises(ValueError):
+        parse_object_name("a.b.c.d", default_db="cp")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_identifiers.py -q`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `identifiers.py`**
+
+```python
+# crdb_dump/utils/identifiers.py
+from dataclasses import dataclass
+
+
+def quote_ident(name: str) -> str:
+    """Quote a single SQL identifier for CockroachDB/Postgres."""
+    return '"' + name.replace('"', '""') + '"'
+
+
+@dataclass(frozen=True)
+class ObjectName:
+    database: str
+    schema: str
+    table: str
+
+    def fq_quoted(self) -> str:
+        return ".".join(quote_ident(p) for p in (self.database, self.schema, self.table))
+
+    def fq_plain(self) -> str:
+        return f"{self.database}.{self.schema}.{self.table}"
+
+    def file_base(self) -> str:
+        return self.fq_plain()
+
+
+def parse_object_name(s: str, default_db: str, default_schema: str = "public") -> ObjectName:
+    """Parse a user/DB-supplied object name into a three-part ObjectName.
+
+    Accepts ``table`` (schema defaults to ``default_schema``), ``schema.table``
+    (database defaults to ``default_db``), or ``database.schema.table``.
+    Two-part input is treated as ``schema.table``, never legacy ``database.table``.
+    """
+    parts = s.split(".")
+    if len(parts) == 1:
+        return ObjectName(default_db, default_schema, parts[0])
+    if len(parts) == 2:
+        return ObjectName(default_db, parts[0], parts[1])
+    if len(parts) == 3:
+        return ObjectName(parts[0], parts[1], parts[2])
+    raise ValueError(f"Invalid object name '{s}': expected 1, 2, or 3 dot-separated parts")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_identifiers.py -q`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crdb_dump/utils/identifiers.py tests/test_identifiers.py
+git commit -m "Add three-part ObjectName identifier model with quoting"
+```
+
+---
+
+## Task 2: Schema-aware object collection + locality
+
+**Files:**
+- Modify: `crdb_dump/export/schema.py` (`collect_objects`)
+- Modify: `crdb_dump/utils/common.py` (`get_table_locality`)
+- Test: `tests/test_collect_objects.py`
+
+**Interfaces:**
+- Consumes: `ObjectName`, `parse_object_name`, `quote_ident` from Task 1.
+- Produces:
+  - `collect_objects(engine, db, obj_type, logger, retry_count, retry_delay) -> list[str]`
+    now returns three-part `db.schema.name` strings.
+  - `get_table_locality(engine, db, logger) -> dict[str, str]` keyed by `db.schema.table`.
+
+- [ ] **Step 1: Write the failing test (mocked connection)**
+
+```python
+# tests/test_collect_objects.py
+import logging
+from unittest.mock import MagicMock
+from crdb_dump.export.schema import collect_objects
+
+
+class FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+    def execute(self, *_a, **_k):
+        return iter(self._rows)
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+
+def _engine_returning(rows):
+    eng = MagicMock()
+    eng.connect.return_value = FakeConn(rows)
+    return eng
+
+
+def test_collect_tables_includes_non_public_schema():
+    # SHOW TABLES rows: (schema_name, table_name, type, owner, est_rows, locality)
+    rows = [
+        ("public", "users", "table", "root", 0, None),
+        ("cpkit", "tasks", "table", "root", 0, None),
+    ]
+    # USE <db> runs first via execute; collect_objects calls execute twice.
+    eng = MagicMock()
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    conn.execute.side_effect = [None, iter(rows)]
+    eng.connect.return_value = conn
+    result = collect_objects(eng, "cp", "table", logging.getLogger("t"), 1, 0.0)
+    assert "cp.public.users" in result
+    assert "cp.cpkit.tasks" in result
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_collect_objects.py -q`
+Expected: FAIL (returns `cp.users`, `cp.tasks` — schema dropped).
+
+- [ ] **Step 3: Update `collect_objects` to keep schema**
+
+Replace the `collect_objects` body's row handling in `crdb_dump/export/schema.py`:
+
+```python
+def collect_objects(engine, db, obj_type, logger, retry_count, retry_delay):
+    # SHOW results expose schema in column 0 for tables/sequences/types.
+    query_map = {
+        'table': "SHOW TABLES",
+        'view': ("SELECT table_schema, table_name FROM information_schema.views "
+                 "WHERE table_schema NOT IN ('pg_catalog', 'information_schema', 'crdb_internal')"),
+        'sequence': "SHOW SEQUENCES",
+        'type': "SHOW TYPES",
+    }
+    objs = []
+    try:
+        with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
+            conn.execute(text(f"USE {quote_ident(db)}"))
+            result = conn.execute(text(query_map[obj_type]))
+            for row in result:
+                if obj_type == 'view':
+                    schema, name = row[0], row[1]
+                elif obj_type in ('table', 'sequence'):
+                    schema, name = row[0], row[1]      # SHOW TABLES/SEQUENCES: (schema, name, ...)
+                elif obj_type == 'type':
+                    schema, name = row[0], row[1]       # SHOW TYPES: (schema, name)
+                else:
+                    continue
+                if not name:
+                    continue
+                if obj_type == 'type':
+                    enum_check = conn.execute(
+                        text("SELECT 1 FROM pg_type WHERE typname = :n AND typtype = 'e'"),
+                        {"n": name},
+                    ).fetchall()
+                    if not enum_check:
+                        logger.warning(f"Skipping non-enum type: {schema}.{name}")
+                        continue
+                objs.append(f"{db}.{schema}.{name}")
+    except Exception as e:
+        logger.error(f"Error fetching {obj_type}s: {e}")
+    return objs
+```
+
+Add `from crdb_dump.utils.identifiers import quote_ident` to the imports at the top of `schema.py`.
+
+- [ ] **Step 4: Update `get_table_locality` to key by three parts**
+
+In `crdb_dump/utils/common.py`, replace the loop body:
+
+```python
+def get_table_locality(engine, db, logger):
+    """Returns a dict mapping db.schema.table => locality string (or 'N/A')."""
+    from crdb_dump.utils.identifiers import quote_ident
+    mapping = {}
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f"USE {quote_ident(db)}"))
+            result = conn.execute(text("SHOW TABLES"))
+            for row in result:
+                schema_name = row[0]
+                table_name = row[1]
+                locality = row[5] if len(row) > 5 else "N/A"
+                fqname = f"{db}.{schema_name}.{table_name}"
+                mapping[fqname] = locality or "N/A"
+    except Exception as e:
+        logger.warning(f"⚠️ Failed to retrieve table localities: {e}")
+    return mapping
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest tests/test_collect_objects.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crdb_dump/export/schema.py crdb_dump/utils/common.py tests/test_collect_objects.py
+git commit -m "Make object collection and locality map schema-aware (three-part names)"
+```
+
+---
+
+## Task 3: Schema-aware DDL export (full + selective)
+
+**Files:**
+- Modify: `crdb_dump/export/schema.py` (`dump_create_statement`, `resolve_object_types`, `export_schema`, `dump_permissions`)
+- Test: `tests/test_schema_export.py`
+
+**Interfaces:**
+- Consumes: `ObjectName`, `parse_object_name`, `quote_ident`; `collect_objects` (Task 2).
+- Produces:
+  - `dump_all_ddl(engine, db, logger, retry_count, retry_delay) -> str` — returns full
+    DDL from `SHOW CREATE ALL TYPES` then `SHOW CREATE ALL TABLES`.
+  - `dump_create_statement(engine, obj_type, full_name, logger, retry_count, retry_delay) -> str | None`
+    where `full_name` is three-part and SQL uses `ObjectName.fq_quoted()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_schema_export.py
+import logging
+from unittest.mock import MagicMock
+from crdb_dump.export.schema import dump_all_ddl, dump_create_statement
+
+
+def _conn_with(execute_results):
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    conn.execute.side_effect = execute_results
+    return conn
+
+
+def test_dump_all_ddl_types_then_tables():
+    conn = _conn_with([
+        None,                                   # USE db
+        iter([("CREATE TYPE cpkit.status AS ENUM ('a');",)]),  # SHOW CREATE ALL TYPES
+        iter([("CREATE TABLE cpkit.tasks (id INT8 PRIMARY KEY);",)]),  # SHOW CREATE ALL TABLES
+    ])
+    eng = MagicMock()
+    eng.connect.return_value = conn
+    out = dump_all_ddl(eng, "cp", logging.getLogger("t"), 1, 0.0)
+    assert "CREATE TYPE cpkit.status" in out
+    assert out.index("CREATE TYPE") < out.index("CREATE TABLE cpkit.tasks")
+
+
+def test_dump_create_statement_uses_quoted_fq_name():
+    captured = {}
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    def execute(stmt, *a, **k):
+        captured.setdefault("stmts", []).append(str(stmt))
+        if "USE" in str(stmt):
+            return None
+        return iter([("tasks", "CREATE TABLE cpkit.tasks (id INT8 PRIMARY KEY)")])
+    conn.execute.side_effect = execute
+    eng = MagicMock()
+    eng.connect.return_value = conn
+    ddl = dump_create_statement(eng, "TABLE", "cp.cpkit.tasks", logging.getLogger("t"), 1, 0.0)
+    assert ddl.strip().endswith(";")
+    assert any('"cp"."cpkit"."tasks"' in s for s in captured["stmts"])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_schema_export.py -q`
+Expected: FAIL (`dump_all_ddl` missing; `dump_create_statement` uses unqualified name).
+
+- [ ] **Step 3: Implement `dump_all_ddl` and rewrite `dump_create_statement`**
+
+Add at top of `schema.py`:
+```python
+import click
+from datetime import datetime, timezone
+from crdb_dump.utils.identifiers import ObjectName, parse_object_name, quote_ident
+```
+Remove the old `from datetime import datetime` line.
+
+Add:
+```python
+def dump_all_ddl(engine, db, logger, retry_count, retry_delay):
+    parts = []
+    with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
+        conn.execute(text(f"USE {quote_ident(db)}"))
+        try:
+            types = conn.execute(text("SHOW CREATE ALL TYPES"))
+            for row in types:
+                stmt = row[0]
+                if stmt and stmt.strip():
+                    parts.append(stmt.rstrip().rstrip(";") + ";")
+        except Exception as e:
+            logger.warning(f"⚠️ SHOW CREATE ALL TYPES failed: {e}")
+        tables = conn.execute(text("SHOW CREATE ALL TABLES"))
+        for row in tables:
+            stmt = row[0]
+            if stmt and stmt.strip():
+                parts.append(stmt.rstrip().rstrip(";") + ";")
+    return "\n".join(parts) + ("\n" if parts else "")
+```
+
+Rewrite `dump_create_statement`:
+```python
+def dump_create_statement(engine, obj_type, full_name, logger, retry_count, retry_delay):
+    obj = parse_object_name(full_name, default_db=full_name.split('.')[0])
+    try:
+        with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
+            conn.execute(text(f"USE {quote_ident(obj.database)}"))
+            if obj_type == "TYPE":
+                result = conn.execute(text("SHOW CREATE ALL TYPES"))
+                matches = [r[0] for r in result
+                           if r[0] and obj.table in r[0] and r[0].startswith("CREATE TYPE")]
+                if matches:
+                    return matches[0].rstrip().rstrip(";") + ";\n"
+                logger.warning(f"Type {obj.fq_plain()} not found in SHOW CREATE ALL TYPES")
+                return None
+            result = conn.execute(text(f"SHOW CREATE {obj_type} {obj.fq_quoted()}"))
+            rows = list(result)
+            if rows and len(rows[0]) > 1:
+                return rows[0][1].rstrip().rstrip(";") + ";\n"
+            logger.warning(f"No DDL returned for {obj_type} {obj.fq_plain()}")
+            return None
+    except Exception as e:
+        logger.error(f"Failed to get DDL for {obj_type} {full_name}: {e}")
+        return None
+```
+
+- [ ] **Step 4: Make `resolve_object_types` schema-aware**
+
+Replace `resolve_object_types` so it parses three-part names and queries by schema:
+```python
+def resolve_object_types(engine, object_names, logger, retry_count, retry_delay):
+    mapping = {}
+    with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
+        for obj_str in object_names:
+            obj = parse_object_name(obj_str, default_db=obj_str.split('.')[0])
+            conn.execute(text(f"USE {quote_ident(obj.database)}"))
+            kind = None
+            res = conn.execute(text(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema = :s AND table_name = :n"
+            ), {"s": obj.schema, "n": obj.table}).fetchone()
+            if res:
+                kind = "TABLE"
+            if not kind:
+                res = conn.execute(text(
+                    "SELECT 1 FROM information_schema.views "
+                    "WHERE table_schema = :s AND table_name = :n"
+                ), {"s": obj.schema, "n": obj.table}).fetchone()
+                if res:
+                    kind = "VIEW"
+            if not kind:
+                res = conn.execute(text(
+                    "SELECT 1 FROM pg_type WHERE typname = :n"
+                ), {"n": obj.table}).fetchone()
+                if res:
+                    kind = "TYPE"
+            if not kind:
+                seqs = conn.execute(text("SHOW SEQUENCES")).fetchall()
+                if obj.table in [r[1] for r in seqs]:
+                    kind = "SEQUENCE"
+            if kind:
+                mapping[obj.fq_plain()] = kind
+            else:
+                logger.warning(f"⚠️ Could not determine type of object: {obj.fq_plain()}")
+    return mapping
+```
+
+- [ ] **Step 5: Rewrite `export_schema` to use full vs selective paths and truncate output**
+
+Replace `export_schema` body's object-gathering and writing logic:
+```python
+def export_schema(opts, out_dir, logger):
+    engine = get_sqlalchemy_engine(opts)
+    db = opts["db"]
+    parallel = opts.get("parallel", False)
+    per_table = opts.get("per_table", False)
+    out_format = opts.get("out_format", "sql")
+    os.makedirs(out_dir, exist_ok=True)
+
+    include = opts.get("tables")
+    exclude = opts.get("exclude_tables")
+    retry_count = opts.get("retry_count", 3)
+    retry_delay = opts.get("retry_delay", 1000) / 1000.0
+    region_filter = opts.get("region")
+    locality_map = get_table_locality(engine, db, logger)
+
+    if include and exclude:
+        raise click.UsageError("You cannot use --tables and --exclude-tables at the same time.")
+
+    aggregate_file = f"{out_dir}/{db}_schema.sql"
+
+    # Full-database, unfiltered, SQL output -> native bulk DDL (dependency-ordered).
+    if not include and not exclude and not region_filter and out_format == "sql" and not per_table:
+        ddl = dump_all_ddl(engine, db, logger, retry_count, retry_delay)
+        write_file(aggregate_file, ddl)
+        logger.info(f"Wrote: {aggregate_file}")
+        if opts.get("include_permissions"):
+            dump_permissions(engine, out_dir, logger, retry_count, retry_delay)
+        return
+
+    # Selective / per-table / json / yaml path.
+    if include:
+        tables_fq = validate_fq_table_names(include.split(','), db)
+        object_map = resolve_object_types(engine, tables_fq, logger, retry_count, retry_delay)
+        all_objects = [(typ, name) for name, typ in object_map.items()]
+    else:
+        tables = collect_objects(engine, db, 'table', logger, retry_count, retry_delay)
+        views = collect_objects(engine, db, 'view', logger, retry_count, retry_delay)
+        sequences = collect_objects(engine, db, 'sequence', logger, retry_count, retry_delay)
+        types = collect_objects(engine, db, 'type', logger, retry_count, retry_delay)
+        all_objects = ([("TYPE", n) for n in types] +
+                       [("SEQUENCE", n) for n in sequences] +
+                       [("TABLE", n) for n in tables] +
+                       [("VIEW", n) for n in views])
+        if region_filter:
+            before = len(all_objects)
+            all_objects = [o for o in all_objects
+                           if region_filter.upper() in locality_map.get(o[1], "").upper()]
+            logger.info(f"📍 Region filter: {region_filter} — selected {len(all_objects)}/{before}")
+        if exclude:
+            exclude_set = set(validate_fq_table_names(exclude.split(','), db))
+            all_objects = [o for o in all_objects if o[1] not in exclude_set]
+
+    if opts.get("include_permissions"):
+        dump_permissions(engine, out_dir, logger, retry_count, retry_delay)
+
+    # Truncate aggregate file once before appending per-object DDL.
+    if not per_table and out_format == "sql":
+        write_file(aggregate_file, "")
+
+    dump_data = []
+
+    def process(obj_type, full_name):
+        ddl = dump_create_statement(engine, obj_type, full_name, logger, retry_count, retry_delay)
+        if not ddl:
+            return
+        dump_data.append({"name": full_name, "type": obj_type, "ddl": ddl.strip()})
+        if per_table and out_format == "sql":
+            filename = f"{out_dir}/{obj_type.lower()}_{full_name}.sql"
+            write_file(filename, f"-- {obj_type}: {full_name}\n{ddl}\n")
+            logger.info(f"Wrote: {filename}")
+        elif not per_table and out_format == "sql":
+            with open(aggregate_file, "a") as f:
+                f.write(f"-- {obj_type}: {full_name}\n{ddl}\n\n")
+            logger.info(f"Appended {full_name} to {aggregate_file}")
+
+    if parallel:
+        with ThreadPoolExecutor() as executor:
+            list(executor.map(lambda a: process(*a), all_objects))
+    else:
+        for obj in all_objects:
+            process(*obj)
+
+    if out_format == "json":
+        write_file(f"{out_dir}/{db}_schema.json", json.dumps(to_json_literal(dump_data), indent=2))
+    elif out_format == "yaml":
+        write_file(f"{out_dir}/{db}_schema.yaml", yaml.dump(to_json_literal(dump_data), sort_keys=False))
+```
+
+Also update the `wrapped_*` lambda removals: delete the now-unused `wrapped_dump_create`,
+`wrapped_collect_objects`, `wrapped_resolve_types`, `wrapped_dump_permissions` lines (calls
+now pass retry args directly).
+
+- [ ] **Step 6: Fix `datetime.utcnow()` in `dump_permissions`**
+
+In `dump_permissions`, change:
+```python
+f"-- Exported at: {datetime.now(timezone.utc).isoformat()} UTC",
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `python -m pytest tests/test_schema_export.py tests/test_identifiers.py tests/test_collect_objects.py -q`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crdb_dump/export/schema.py tests/test_schema_export.py
+git commit -m "Schema export: native bulk DDL for full dumps, schema-aware selective dumps"
+```
+
+---
+
+## Task 4: Update `validate_fq_table_names` + `normalize_filename`
+
+**Files:**
+- Modify: `crdb_dump/utils/io.py`
+- Test: `tests/test_io_names.py`
+
+**Interfaces:**
+- Produces: `validate_fq_table_names(tables, db) -> list[str]` accepts 2- or 3-part names,
+  returns normalized three-part `db.schema.table` strings.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_io_names.py
+import pytest
+from crdb_dump.utils.io import validate_fq_table_names
+
+
+def test_accepts_schema_table_and_normalizes():
+    assert validate_fq_table_names(["cpkit.tasks"], "cp") == ["cp.cpkit.tasks"]
+
+def test_accepts_full_three_part():
+    assert validate_fq_table_names(["cp.cpkit.tasks"], "cp") == ["cp.cpkit.tasks"]
+
+def test_bare_table_defaults_public():
+    assert validate_fq_table_names(["tasks"], "cp") == ["cp.public.tasks"]
+
+def test_rejects_wrong_db_prefix():
+    with pytest.raises(ValueError):
+        validate_fq_table_names(["other.cpkit.tasks"], "cp")
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_io_names.py -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Rewrite `validate_fq_table_names` and `normalize_filename`**
+
+```python
+# in crdb_dump/utils/io.py
+from crdb_dump.utils.identifiers import parse_object_name
+
+def validate_fq_table_names(tables, db):
+    out = []
+    for t in tables:
+        obj = parse_object_name(t, default_db=db)
+        if obj.database != db:
+            raise ValueError(
+                f"❌ Invalid table name '{t}': database '{obj.database}' does not match --db '{db}'")
+        out.append(obj.fq_plain())
+    return out
+
+def normalize_filename(obj_type, full_name):
+    return f"{obj_type.lower()}_{full_name}.sql"
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_io_names.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crdb_dump/utils/io.py tests/test_io_names.py
+git commit -m "Normalize table-name validation to three-part names"
+```
+
+---
+
+## Task 5: Schema-aware data export + three-part filenames
+
+**Files:**
+- Modify: `crdb_dump/export/data.py` (`export_table_data`, `export_data`)
+- Test: `tests/test_data_export.py`
+
+**Interfaces:**
+- Consumes: `ObjectName`, `parse_object_name` from Task 1.
+- Produces: data files named `<db.schema.table>_NNN.csv[.gz]` / `_NNN.sql`,
+  manifest `<db.schema.table>.manifest.json` with `"table": "db.schema.table"`.
+
+- [ ] **Step 1: Write the failing test for filename/manifest naming**
+
+```python
+# tests/test_data_export.py
+import json, os, logging
+from unittest.mock import MagicMock
+from crdb_dump.export import data as data_mod
+
+
+def test_export_table_data_three_part_naming(tmp_path):
+    # Two execute calls: columns query, then one page of rows, then empty page.
+    cols = [("id",), ("name",)]
+    page1 = [(1, "a"), (2, "b")]
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    results = [iter(cols), MagicMock(fetchall=lambda: page1), MagicMock(fetchall=lambda: [])]
+    conn.execute.side_effect = results
+    engine = MagicMock()
+    engine.connect.return_value = conn
+
+    total = data_mod.export_table_data(
+        engine, "cp.cpkit.tasks", str(tmp_path), "sql", False, None, False,
+        None, False, 1000, False, logging.getLogger("t"), {}, 1, 0.0, {})
+    assert total == 2
+    files = os.listdir(tmp_path)
+    assert any(f.startswith("cp.cpkit.tasks_001") and f.endswith(".sql") for f in files)
+    manifest = json.load(open(tmp_path / "cp.cpkit.tasks.manifest.json"))
+    assert manifest["table"] == "cp.cpkit.tasks"
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_data_export.py -q`
+Expected: FAIL (current code crashes on three-part split / uses old names).
+
+- [ ] **Step 3: Rewrite `export_table_data` head + naming + SQL**
+
+In `crdb_dump/export/data.py`, add import:
+```python
+from crdb_dump.utils.identifiers import parse_object_name
+```
+Replace the top of `export_table_data` (the `db, tbl = table.split('.')` block through column query):
+```python
+    try:
+        obj = parse_object_name(table, default_db=table.split('.')[0])
+        base_name = obj.file_base()
+        with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
+            cols_res = conn.execute(text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = :t AND table_schema = :s ORDER BY ordinal_position"
+            ), {"t": obj.table, "s": obj.schema})
+            columns = [row[0] for row in cols_res]
+```
+Replace the SELECT query line:
+```python
+                query = f"SELECT * FROM {obj.fq_quoted()} {order_clause} OFFSET {offset} LIMIT {batch_size}"
+```
+Replace the out_path computation:
+```python
+                out_path = os.path.join(
+                    out_dir,
+                    f"{base_name}_{chunk_index:03d}.csv.gz" if compress
+                    else f"{base_name}_{chunk_index:03d}.csv"
+                ) if export_format == 'csv' else os.path.join(
+                    out_dir, f"{base_name}_{chunk_index:03d}.sql")
+```
+Replace the INSERT write to use quoted FQ name and quoted columns:
+```python
+                elif export_format == 'sql':
+                    col_list = ", ".join(quote_ident(c) for c in columns)
+                    with open(out_path, 'w') as f:
+                        for row in rows:
+                            vals = ", ".join(to_sql_literal(v) for v in row)
+                            f.write(f"INSERT INTO {obj.fq_quoted()} ({col_list}) VALUES ({vals});\n")
+```
+Add `quote_ident` to the identifiers import:
+```python
+from crdb_dump.utils.identifiers import parse_object_name, quote_ident
+```
+Replace the manifest path + content:
+```python
+            manifest_path = os.path.join(out_dir, f"{base_name}.manifest.json")
+            region = locality_map.get(table, "N/A")
+            with open(manifest_path, 'w') as mf:
+                json.dump({"table": obj.fq_plain(), "region": region, "chunks": manifest}, mf, indent=2)
+```
+
+- [ ] **Step 4: Fix the order-column membership check**
+
+The `if col not in columns` block stays valid (columns now schema-filtered). No change needed.
+
+- [ ] **Step 5: Fix `export_data` summary key collision**
+
+Replace the summary aggregation (was keyed by `tbl.split('.')[-1]`, which collides across schemas):
+```python
+    table_row_counts = {t[1]: count for t, count in zip(data_tasks, results)}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `python -m pytest tests/test_data_export.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crdb_dump/export/data.py tests/test_data_export.py
+git commit -m "Data export: schema-aware queries, three-part file/manifest naming"
+```
+
+---
+
+## Task 6: Connection layer honors opts on load
+
+**Files:**
+- Modify: `crdb_dump/utils/db_connection.py` (`get_psycopg_connection`)
+- Modify: `crdb_dump/loader/loader.py` (pass opts through)
+- Test: `tests/test_db_connection.py`
+
+**Interfaces:**
+- Produces: `get_psycopg_connection(opts=None) -> connection`. With `CRDB_URL` set, uses it;
+  else builds from `opts` (`host`, `port`, `db`, `certs_dir`) mirroring `get_sqlalchemy_engine`.
+
+- [ ] **Step 1: Write the failing test (URL building, no real connect)**
+
+```python
+# tests/test_db_connection.py
+from unittest.mock import patch
+from crdb_dump.utils import db_connection as dbc
+
+
+def test_psycopg_uses_opts_when_no_env(monkeypatch):
+    monkeypatch.delenv("CRDB_URL", raising=False)
+    captured = {}
+    def fake_connect(dsn):
+        captured["dsn"] = dsn
+        return "CONN"
+    monkeypatch.setattr(dbc.psycopg2, "connect", fake_connect)
+    conn = dbc.get_psycopg_connection({"host": "h1", "port": 5432, "db": "cp"})
+    assert conn == "CONN"
+    assert "h1" in captured["dsn"] and "cp" in captured["dsn"]
+
+
+def test_psycopg_prefers_env(monkeypatch):
+    monkeypatch.setenv("CRDB_URL", "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable")
+    captured = {}
+    monkeypatch.setattr(dbc.psycopg2, "connect", lambda dsn: captured.setdefault("dsn", dsn) or "C")
+    dbc.get_psycopg_connection({"host": "ignored"})
+    assert captured["dsn"].startswith("postgresql://")
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_db_connection.py -q`
+Expected: FAIL (signature takes no opts).
+
+- [ ] **Step 3: Rewrite `get_psycopg_connection`**
+
+```python
+def get_psycopg_connection(opts=None):
+    url = os.getenv("CRDB_URL")
+    if url:
+        pg_url = url.replace("cockroachdb://", "postgresql://", 1)
+        return psycopg2.connect(pg_url)
+    opts = opts or {}
+    host = opts.get("host", "localhost")
+    port = opts.get("port", 26257)
+    db = opts.get("db", "defaultdb")
+    base = f"postgresql://root@{host}:{port}/{db}"
+    if opts.get("certs_dir"):
+        base += (f"?sslmode=verify-full"
+                 f"&sslrootcert={opts['certs_dir']}/ca.crt"
+                 f"&sslcert={opts['certs_dir']}/client.root.crt"
+                 f"&sslkey={opts['certs_dir']}/client.root.key")
+    else:
+        base += "?sslmode=disable"
+    return psycopg2.connect(base)
+```
+
+- [ ] **Step 4: Thread opts through the loader**
+
+In `crdb_dump/loader/loader.py`, update `validate_csv_header` and `load_chunk` to use opts:
+```python
+def validate_csv_header(table, filepath, logger, opts=None):
+    from crdb_dump.utils.identifiers import parse_object_name
+    obj = parse_object_name(table, default_db=table.split('.')[0])
+    conn = get_psycopg_connection(opts)
+    with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = %s AND table_schema = %s ORDER BY ordinal_position",
+            (obj.table, obj.schema))
+        db_columns = [row[0] for row in cur.fetchall()]
+    with open(filepath, 'r') as f:
+        csv_header = next(__import__("csv").reader(f))
+    if db_columns != csv_header:
+        logger.warning(f"Header mismatch for {table}:\nDB:   {db_columns}\nFile: {csv_header}")
+        return False
+    return True
+```
+And in `load_chunk`, use opts for the connection and a quoted FQ COPY target:
+```python
+        if validate and not validate_csv_header(table, local_path, logger, opts):
+            logger.error(f"Skipping load for {file_path} due to header mismatch.")
+            return False
+        from crdb_dump.utils.identifiers import parse_object_name
+        obj = parse_object_name(table, default_db=table.split('.')[0])
+        conn = get_psycopg_connection(opts)
+        with conn.cursor() as cur:
+            with open(local_path, "r") as f:
+                sql = f"COPY {obj.fq_quoted()} FROM STDIN WITH CSV HEADER"
+                cur.copy_expert(sql, f)
+        conn.commit()
+        conn.close()
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest tests/test_db_connection.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crdb_dump/utils/db_connection.py crdb_dump/loader/loader.py tests/test_db_connection.py
+git commit -m "Loader honors connection opts; schema-aware COPY and CSV validation"
+```
+
+---
+
+## Task 7: Robust schema-file splitting with sqlparse
+
+**Files:**
+- Modify: `crdb_dump/loader/loader.py` (`load_schema`)
+- Test: `tests/test_load_schema_split.py`
+
+**Interfaces:**
+- Produces: `load_schema(schema_path, engine, logger)` splits statements via `sqlparse.split`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_load_schema_split.py
+from unittest.mock import MagicMock
+from crdb_dump.loader.loader import _split_sql_statements
+
+
+def test_split_ignores_semicolons_in_string_literals():
+    sql = "INSERT INTO t VALUES ('a;b'); CREATE TABLE x (id INT);"
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 2
+    assert "a;b" in stmts[0]
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_load_schema_split.py -q`
+Expected: FAIL (`_split_sql_statements` missing).
+
+- [ ] **Step 3: Implement splitter and use it**
+
+In `crdb_dump/loader/loader.py` add `import sqlparse` and:
+```python
+def _split_sql_statements(sql):
+    return [s.strip().rstrip(";").strip()
+            for s in sqlparse.split(sql) if s.strip().rstrip(";").strip()]
+```
+In `load_schema`, replace the `statements = [...]` line:
+```python
+    statements = _split_sql_statements(sql)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_load_schema_split.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crdb_dump/loader/loader.py tests/test_load_schema_split.py
+git commit -m "Use sqlparse for safe schema statement splitting"
+```
+
+---
+
+## Task 8: Verify-checksum + CLI consistency for three-part names
+
+**Files:**
+- Modify: `crdb_dump/verify/checksum.py`
+- Test: `tests/test_checksum.py`
+
+**Interfaces:**
+- Produces: `verify_checksums` resolves manifests by `db.schema.table` base names.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_checksum.py
+import json, logging
+from crdb_dump.verify.checksum import verify_checksums
+
+
+def test_verify_uses_three_part_manifest(tmp_path):
+    base = "cp.cpkit.tasks"
+    data_file = tmp_path / f"{base}_001.sql"
+    data_file.write_text("INSERT INTO x VALUES (1);\n")
+    import hashlib
+    h = hashlib.sha256(data_file.read_bytes()).hexdigest()
+    (tmp_path / f"{base}.manifest.json").write_text(json.dumps(
+        {"table": base, "region": "N/A", "chunks": [{"file": f"{base}_001.sql", "rows": 1, "sha256": h}]}))
+    opts = {"tables": "cp.cpkit.tasks", "db": "cp", "retry_count": 1, "retry_delay": 0}
+    # Should not raise and should find the manifest.
+    verify_checksums(opts, str(tmp_path), logging.getLogger("t"))
+```
+
+- [ ] **Step 2: Run to verify fail/inspect**
+
+Run: `python -m pytest tests/test_checksum.py -q`
+Expected: FAIL (base name uses `split('.')[-1]` → `tasks`, manifest not found).
+
+- [ ] **Step 3: Fix base name resolution**
+
+In `crdb_dump/verify/checksum.py`, replace:
+```python
+        base_name = table.split('.')[-1]
+```
+with:
+```python
+        from crdb_dump.utils.identifiers import parse_object_name
+        base_name = parse_object_name(table, default_db=table.split('.')[0]).file_base()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_checksum.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crdb_dump/verify/checksum.py tests/test_checksum.py
+git commit -m "Verify checksums against three-part manifest names"
+```
+
+---
+
+## Task 9: Packaging, Python 3.10, hygiene
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `.gitignore`
+- Create: `CHANGELOG.md`
+- Remove from tracking: `build/`, `dist/`
+
+- [ ] **Step 1: Update `pyproject.toml`**
+
+Set:
+```toml
+version = "0.4.0"
+requires-python = ">=3.10"
+```
+Replace classifiers Python lines with 3.10–3.13 only. Add `sqlparse` to `dependencies`. Add:
+```toml
+[project.optional-dependencies]
+dev = ["pytest"]
+```
+
+- [ ] **Step 2: Update `.gitignore`**
+
+Append:
+```
+build/
+dist/
+*.egg-info/
+logs/
+.venv/
+crdb_dump_output/
+tmp/
+```
+
+- [ ] **Step 3: Untrack build artifacts**
+
+Run:
+```bash
+git rm -r --cached build dist crdb_dump.egg-info 2>/dev/null || true
+```
+
+- [ ] **Step 4: Create `CHANGELOG.md`**
+
+```markdown
+# Changelog
+
+## 0.4.0 (unreleased)
+
+### Breaking
+- Object naming is now three-part `database.schema.table` everywhere
+  (filenames, manifests, resume-log keys, `--tables` input). Pre-0.4.0
+  two-part dumps are not compatible.
+- `--tables` two-part input now means `schema.table` (db from `--db`),
+  not `database.table`.
+- Minimum Python is now 3.10.
+
+### Fixed
+- Export and restore now work for objects in non-`public` schemas.
+- Mixed-case / reserved-word identifiers are correctly quoted.
+- `load` honors `--host/--port/--certs-dir` (previously ignored).
+- Schema export no longer duplicates DDL on re-run.
+- `load` schema splitting handles semicolons inside string/UDF bodies.
+
+### Added
+- Native `SHOW CREATE ALL TYPES` / `SHOW CREATE ALL TABLES` for full dumps
+  (dependency-ordered, FK constraints validated post-load).
+```
+
+- [ ] **Step 5: Verify build + unit tests**
+
+Run:
+```bash
+pip install -e ".[dev]"
+python -m pytest -m unit -q
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml .gitignore CHANGELOG.md
+git commit -m "Require Python 3.10+, bump to 0.4.0, add sqlparse, repo hygiene"
+```
+
+---
+
+## Task 10: Integration tests for non-public schema round-trip
+
+**Files:**
+- Modify: `tests/test_integration.py`
+
+**Interfaces:**
+- Consumes: live CockroachDB via `CRDB_URL`.
+
+- [ ] **Step 1: Add the failing integration test**
+
+```python
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_non_public_schema_roundtrip(tmp_path):
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("CREATE SCHEMA IF NOT EXISTS cpkit")
+    cur.execute("DROP TABLE IF EXISTS cpkit.tasks")
+    cur.execute("CREATE TABLE cpkit.tasks (id INT PRIMARY KEY, name STRING)")
+    cur.execute("INSERT INTO cpkit.tasks VALUES (1, 'a'), (2, 'b')")
+    conn.commit(); cur.close(); conn.close()
+
+    out = tmp_path / "out"
+    runner = CliRunner()
+    r = runner.invoke(main, ["export", "--db=defaultdb", "--data",
+                             "--data-format=csv", f"--out-dir={out}"])
+    assert r.exit_code == 0, r.output
+    db_dir = out / "defaultdb"
+    assert (db_dir / "defaultdb.cpkit.tasks.manifest.json").exists()
+
+    conn = get_psycopg_connection(); cur = conn.cursor()
+    cur.execute("DROP TABLE cpkit.tasks"); conn.commit(); cur.close(); conn.close()
+
+    r = runner.invoke(main, ["load", "--db=defaultdb",
+                             f"--schema={db_dir}/defaultdb_schema.sql",
+                             f"--data-dir={db_dir}", "--validate-csv"])
+    assert r.exit_code == 0, r.output
+    conn = get_psycopg_connection(); cur = conn.cursor()
+    cur.execute("SELECT count(*) FROM cpkit.tasks")
+    assert cur.fetchone()[0] == 2
+    cur.close(); conn.close()
+```
+
+- [ ] **Step 2: Start a local cluster and run integration**
+
+Run:
+```bash
+cockroach start-single-node --insecure --background --store=type=mem,size=1GiB --listen-addr=localhost:26257
+export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+python -m pytest -m integration -q
+```
+Expected: PASS (this is the exact bug Fabio reported — must be green).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_integration.py
+git commit -m "Integration test: non-public schema export/load round-trip"
+```
+
+---
+
+## Task 11: E2E scenario + docs + CLAUDE.md finalization
+
+**Files:**
+- Modify: `test-local.sh` (add non-public schema)
+- Modify: `README.md`
+- Modify: `CLAUDE.md` (already created; confirm accuracy)
+- Modify: `.github/workflows/python-ci.yml`
+
+- [ ] **Step 1: Add a non-public-schema block to `test-local.sh`**
+
+After the table-creation block, add:
+```bash
+echo "📐 Creating non-public schema objects..."
+cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
+  CREATE SCHEMA IF NOT EXISTS cpkit;
+  CREATE TABLE cpkit.tasks (id INT PRIMARY KEY, name STRING);
+  INSERT INTO cpkit.tasks VALUES (1,'a'),(2,'b'),(3,'c');
+"
+```
+And after the main export, assert the schema-qualified manifest exists:
+```bash
+test -f "$BASE_OUT_DIR/${DB_NAME}.cpkit.tasks.manifest.json" \
+  && echo "✅ non-public schema exported" \
+  || { echo "❌ non-public schema NOT exported"; exit 1; }
+```
+
+- [ ] **Step 2: Update README**
+
+Update naming examples to `db.schema.table`, document `--tables` two-part semantics,
+add a "Breaking changes in 0.4.0" note pointing at `CHANGELOG.md`, and update the
+Python badge/requirement text to 3.10+.
+
+- [ ] **Step 3: Update CI matrix**
+
+In `.github/workflows/python-ci.yml`, set the unit-test matrix to
+`python-version: ["3.10", "3.11", "3.12", "3.13"]` and add an integration job
+that runs a `cockroachdb/cockroach` service/container, sets `CRDB_URL`, and runs
+`pytest -m integration`.
+
+- [ ] **Step 4: Run the full e2e**
+
+Run: `./test-local.sh`
+Expected: all steps green, including the new non-public schema assertion.
+
+- [ ] **Step 5: Final full test pass**
+
+Run:
+```bash
+python -m pytest -q
+CRDB_URL=... python -m pytest -m integration -q
+```
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test-local.sh README.md CLAUDE.md .github/workflows/python-ci.yml
+git commit -m "E2E non-public schema scenario, docs, and CI matrix for 3.10+"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** identifier model (T1), schema export full+selective (T2,T3),
+  validation/normalization (T4), data export naming (T5), loader connection+COPY (T6),
+  schema splitting (T7), checksum (T8), packaging/Python 3.10/hygiene (T9),
+  integration non-public (T10), e2e+docs+CI+CLAUDE.md (T11). All spec sections covered.
+- **Placeholders:** none — every code step shows code; every run step shows command + expected.
+- **Type consistency:** `ObjectName.fq_quoted/fq_plain/file_base`, `parse_object_name`,
+  `quote_ident` used with consistent signatures across all tasks.
+- **Out of scope** (keyset pagination, 2-part back-compat, multi-db) intentionally excluded.
+```

--- a/docs/superpowers/specs/2026-06-26-schema-aware-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-26-schema-aware-overhaul-design.md
@@ -1,0 +1,146 @@
+# crdb-dump v0.4.0 — Schema-Aware Overhaul (Design)
+
+Date: 2026-06-26
+Status: Approved-pending-review
+
+## Problem
+
+`crdb-dump` assumes two-part `database.table` object names throughout. CockroachDB
+objects are three-part `database.schema.table`. Any object not in the `public`
+schema is mishandled: it is silently re-qualified to the wrong name, fails its
+`SHOW CREATE`, or crashes the data exporter (`db, tbl = table.split('.')` raises on
+three parts). A user (Fabio) hit this when exporting tables in a non-`public`
+schema and patched it locally.
+
+Beyond the reported bug, the codebase has correctness, safety, and packaging gaps
+that should be addressed in the same pass.
+
+## Goals
+
+1. Make export **and** restore fully correct for objects in any schema (not just `public`).
+2. Bring the project up to current best practices (safety, restore ordering, packaging, tests, docs).
+3. Require Python >= 3.10.
+
+## Decisions (from brainstorming)
+
+- **Scope:** Comprehensive overhaul, implemented in phases under one spec.
+- **DDL strategy:** Use CockroachDB-native `SHOW CREATE ALL TABLES` / `SHOW CREATE ALL TYPES`
+  for full-database export (dependency-ordered, FK constraints split out). Per-object
+  `SHOW CREATE` for selective/filtered export.
+- **Compatibility:** Clean break to three-part `database.schema.table` naming for
+  filenames, manifests, and resume-log keys. No backward compatibility with old
+  two-part manifests.
+- **Version:** bump to `0.4.0` (breaking).
+- **New dependency:** `sqlparse` for safe SQL statement splitting on load.
+
+## Architecture
+
+### 1. Identifier model — `crdb_dump/utils/identifiers.py` (new, foundational)
+
+Single source of truth for object identity and quoting. Everything else uses it.
+
+- `ObjectName(database, schema, table)` dataclass.
+- `parse_object_name(s, default_db, default_schema="public") -> ObjectName`
+  - Accepts `table`, `schema.table`, or `db.schema.table`.
+  - For CLI `--tables` input, the value is interpreted as `db.schema.table` or
+    `schema.table` (database defaults to `--db`). Two-part input is treated as
+    `schema.table`, **never** the legacy `db.table`. This is documented in `--help`
+    and README as a breaking change.
+- `quote_ident(name) -> str` — double-quote, escape embedded quotes. Handles
+  mixed-case and reserved words.
+- `ObjectName.fq_quoted() -> '"db"."schema"."table"'` — for SQL.
+- `ObjectName.fq_plain() -> 'db.schema.table'` — for filenames/manifests/logs/resume keys.
+- `ObjectName.file_base() -> 'db.schema.table'` — filename stem.
+
+This eliminates, in one place: schema-dropping, SQL injection via interpolated
+identifiers, and mixed-case/reserved-word breakage.
+
+### 2. Schema export — `crdb_dump/export/schema.py`
+
+- **Full-database** (no `--tables`): emit `SHOW CREATE ALL TYPES` (enum filter) first,
+  then `SHOW CREATE ALL TABLES` (sequences → tables → views in dependency order,
+  with FK constraints emitted as trailing `ALTER ... ADD CONSTRAINT ... ; ... VALIDATE`).
+- **Selective** (`--tables` / `--exclude-tables` / `--region`): schema-aware object-type
+  resolver (no hardcoded `public`); per-object `SHOW CREATE <type> <fq_quoted>`.
+- Fixes folded in:
+  - `import click` (currently missing — `click.UsageError` at line ~153 raises `NameError`).
+  - Truncate the aggregate `<db>_schema.sql` before writing (currently appended, so
+    re-runs duplicate DDL).
+  - Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`.
+  - Permissions export (`dump_permissions`) becomes schema-aware in object names.
+- JSON/YAML schema output preserved, keyed by three-part names.
+
+### 3. Data export — `crdb_dump/export/data.py`
+
+- Parse each table with `ObjectName`.
+- Column discovery query filters on **both** `table_name` and `table_schema`.
+- `SELECT` / `INSERT` use `fq_quoted()`.
+- Output naming: `db.schema.table_001.sql`, `db.schema.table_001.csv[.gz]`,
+  manifest `db.schema.table.manifest.json`, manifest `"table"` field = `db.schema.table`.
+- Keep OFFSET/LIMIT chunking. (Keyset pagination noted as a future perf item — out of scope.)
+
+### 4. Loader — `crdb_dump/loader/loader.py`, `crdb_dump/utils/db_connection.py`
+
+- **Connection bug fix:** `get_psycopg_connection` must honor the same connection
+  inputs as the engine (`CRDB_URL`, else `--host/--port/--db/--certs-dir`). Today it
+  ignores opts and only reads `CRDB_URL`/localhost, so `load --host ...` silently
+  targets the wrong cluster.
+- `COPY` targets `fq_quoted()`; `validate_csv_header` filters by schema too.
+- **Schema apply:** replace naive `sql.split(';')` with `sqlparse.split()` to handle
+  semicolons inside string literals, UDF bodies, and dollar-quoting.
+- Manifests carry three-part names; resume-log keys derived from `fq_plain()`.
+
+### 5. Packaging & hygiene — `pyproject.toml`, `.gitignore`
+
+- `requires-python = ">=3.10"`; classifiers for 3.10–3.13; drop 3.7–3.9.
+- Version → `0.4.0`.
+- Add `sqlparse` dependency; add `[project.optional-dependencies].dev` (pytest, etc.).
+- Stop tracking `build/` and `dist/`; add them plus `logs/`, `*.egg-info/`, output
+  dirs to `.gitignore`.
+- Add `CHANGELOG.md` with the breaking-change entry.
+
+## Testing strategy (REQUIRED before any push)
+
+Per user preference, every change must be verified at three levels and pass before a
+push is proposed; commit messages carry no AI/bot attribution.
+
+- **Unit** (`tests/test_unit.py` + new files, no DB):
+  - `identifiers`: parse/quote/fq for public, non-public, mixed-case, reserved-word,
+    embedded-quote, and 2- vs 3-part inputs.
+  - Filename/manifest stem generation.
+  - Schema-qualification logic with mocked SQLAlchemy connections.
+  - Existing literal/type tests retained.
+- **Integration** (`tests/test_integration.py`, gated on `CRDB_URL`):
+  - Round-trip test that creates a **non-`public`** schema + table, exports, drops,
+    loads, and asserts row/DDL fidelity — the exact gap reported.
+  - Mixed-case identifier round-trip.
+- **E2E** (`test-local.sh`): extend with a non-`public`-schema scenario across
+  export → verify → load → resume → region → S3. Must run green against a live
+  CockroachDB before any push.
+- **CI** (`.github/workflows/python-ci.yml`): unit matrix on 3.10–3.13; integration
+  job against a CockroachDB service container.
+
+## Docs & memory
+
+- README: three-part naming, schema-aware examples, breaking-change note, `--tables`
+  input semantics.
+- New repo-root `CLAUDE.md`: architecture map, the identifier-model convention,
+  module responsibilities, how to run unit/integration/e2e, and the
+  test-before-push / no-bot-commit rules.
+
+## Implementation phases
+
+1. `identifiers` module + unit tests.
+2. Schema export rewrite (full + selective) + tests.
+3. Data export rewrite (naming, qualification) + tests.
+4. Loader + connection fix + sqlparse + tests.
+5. Packaging, `.gitignore`, CHANGELOG, Python 3.10 bump.
+6. Integration tests + `test-local.sh` non-public scenario + CI.
+7. README + `CLAUDE.md`.
+8. Full unit + integration + e2e green, then propose push.
+
+## Out of scope
+
+- Keyset/cursor pagination for very large tables (future perf work).
+- Backward compatibility with pre-0.4.0 two-part manifests.
+- Cross-database (multi-db) single-invocation export.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crdb-dump"
-version = "0.3.0"
+version = "0.4.0"
 description = "A CLI tool to export and import schema definitions and data from CockroachDB in SQL, JSON, YAML, or chunked CSV formats."
 
 authors = [
@@ -12,25 +12,31 @@ authors = [
 ]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Quality Assurance",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent"
 ]
 dependencies = [
-    "sqlalchemy",
-    "sqlalchemy-cockroachdb",
-    "click",
-    "pyyaml",
-    "psycopg2-binary",
-    "boto3"
+    "sqlalchemy>=2.0.51",
+    "sqlalchemy-cockroachdb>=2.0.4",
+    "click>=8.4.2",
+    "pyyaml>=6.0.3",
+    "psycopg2-binary>=2.9.12",
+    "boto3>=1.43.36",
+    "sqlparse>=0.5.5"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0"
 ]
 
 [project.scripts]
@@ -38,3 +44,11 @@ crdb-dump = "crdb_dump.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
+include = ["crdb_dump*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra -q"
+markers = [
+    "integration: mark a test as requiring CockroachDB (e.g., Docker-based)",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-addopts = -ra -q
-testpaths = tests
-markers =
-    integration: mark a test as requiring CockroachDB (e.g., Docker-based)

--- a/test-local.sh
+++ b/test-local.sh
@@ -74,6 +74,15 @@ cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
   ALTER TABLE logins SET LOCALITY REGIONAL BY TABLE IN 'us-west1';
 "
 
+echo "📐 Creating non-public schema objects + a VECTOR column..."
+cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
+  CREATE SCHEMA IF NOT EXISTS cpkit;
+  CREATE TABLE cpkit.tasks (id INT PRIMARY KEY, name STRING);
+  INSERT INTO cpkit.tasks VALUES (1,'a'),(2,'b'),(3,'c');
+  CREATE TABLE embeddings (id INT PRIMARY KEY, embd VECTOR(3));
+  INSERT INTO embeddings VALUES (1,'[1.5,2,3.25]'),(2,'[0,0,0]');
+"
+
 echo "📊 Inserting test data..."
 cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
   INSERT INTO users
@@ -100,6 +109,14 @@ crdb-dump --verbose export \
   --data-format=csv \
   --chunk-size=1000 \
   --out-dir="$OUT_DIR"
+
+echo "🔎 Asserting non-public schema + VECTOR were exported..."
+test -f "$BASE_OUT_DIR/${DB_NAME}.cpkit.tasks.manifest.json" \
+  && echo "✅ non-public schema (cpkit.tasks) exported" \
+  || { echo "❌ non-public schema NOT exported"; exit 1; }
+test -f "$BASE_OUT_DIR/${DB_NAME}.public.embeddings.manifest.json" \
+  && echo "✅ VECTOR table (embeddings) exported" \
+  || { echo "❌ VECTOR table NOT exported"; exit 1; }
 
 echo "🧪 Verifying chunks..."
 crdb-dump --verbose export \

--- a/test-local.sh
+++ b/test-local.sh
@@ -5,6 +5,22 @@ set -euo pipefail
 # script -c $(cockroach demo --nodes=3 --demo-locality=region=us-east1:region=us-west1:region=us-central1 --no-example-database --empty) /dev/null >/dev/null
 #
 
+# Resolve the crdb-dump CLI: prefer the installed console script, otherwise fall
+# back to running the module directly (works as long as the package is importable,
+# e.g. after `pip install -e .` even without the console script on PATH).
+if command -v crdb-dump >/dev/null 2>&1; then
+  CRDB_DUMP="crdb-dump"
+elif python -c "import crdb_dump" >/dev/null 2>&1; then
+  CRDB_DUMP="python -m crdb_dump.cli"
+elif python3 -c "import crdb_dump" >/dev/null 2>&1; then
+  CRDB_DUMP="python3 -m crdb_dump.cli"
+else
+  echo "❌ crdb-dump not found. Install it first, e.g.:"
+  echo "     python -m venv .venv && source .venv/bin/activate && pip install -e ."
+  exit 1
+fi
+echo "🔧 Using CLI: $CRDB_DUMP"
+
 DB_NAME="defaultdb"
 OUT_DIR="tmp/export-test"
 BASE_OUT_DIR="$OUT_DIR/$DB_NAME"
@@ -135,7 +151,7 @@ cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
 "
 
 echo "📦 Exporting schema (full-DB DDL) and data..."
-crdb-dump --verbose export \
+$CRDB_DUMP --verbose export \
   --db="$DB_NAME" \
   --data \
   --data-format=csv \
@@ -151,13 +167,13 @@ test -f "$BASE_OUT_DIR/${DB_NAME}.public.embeddings.manifest.json" \
   || { echo "❌ VECTOR table NOT exported"; exit 1; }
 
 echo "🧪 Verifying chunks..."
-crdb-dump --verbose export \
+$CRDB_DUMP --verbose export \
   --db="$DB_NAME" \
   --verify \
   --out-dir="$OUT_DIR"
 
 echo "🔍 Dry run import (should not write to DB)..."
-crdb-dump --verbose load \
+$CRDB_DUMP --verbose load \
   --db="$DB_NAME" \
   --schema="$SCHEMA_FILE" \
   --data-dir="$DATA_DIR" \
@@ -174,7 +190,7 @@ echo "✅ Database recreated empty"
 
 echo "🧪 Full restore with --validate-csv and --parallel-load"
 rm -rf "$OUT_DIR/resume-main"
-crdb-dump --verbose load \
+$CRDB_DUMP --verbose load \
   --db="$DB_NAME" \
   --schema="$SCHEMA_FILE" \
   --data-dir="$DATA_DIR" \
@@ -196,7 +212,7 @@ for ORDER_FLAG in "" "--data-order=id" "--data-order=id --data-order-desc"; do
     for LIMIT in 100 1000 ""; do
       echo "▶️ Exporting with $ORDER_FLAG $PARALLEL --data-limit=$LIMIT"
       OUT_SUBDIR="$OUT_DIR/variant_$(date +%s%N)"
-      crdb-dump --verbose export \
+      $CRDB_DUMP --verbose export \
         --db="$DB_NAME" \
         --per-table \
         --data \
@@ -207,14 +223,14 @@ for ORDER_FLAG in "" "--data-order=id" "--data-order=id --data-order-desc"; do
         ${LIMIT:+--data-limit=$LIMIT} \
         --out-dir="$OUT_SUBDIR"
 
-      crdb-dump --verbose export --db="$DB_NAME" --verify --out-dir="$OUT_SUBDIR"
+      $CRDB_DUMP --verbose export --db="$DB_NAME" --verify --out-dir="$OUT_SUBDIR"
     done
   done
 done
 
 echo "🧪 Testing resume idempotency..."
 echo "▶️ Re-running the load — every chunk should be SKIPPED (already loaded)..."
-RESUME_OUT=$(crdb-dump --verbose load \
+RESUME_OUT=$($CRDB_DUMP --verbose load \
   --db="$DB_NAME" \
   --data-dir="$DATA_DIR" \
   --resume-log-dir="$OUT_DIR/resume-main" \
@@ -229,7 +245,7 @@ echo "✅ Resume idempotency verified (no chunk reloaded)"
 
 if [ "$MULTIREGION" = true ]; then
   echo "🌍 Exporting $PRIMARY_REGION only..."
-  crdb-dump --verbose export \
+  $CRDB_DUMP --verbose export \
     --db="$DB_NAME" \
     --data \
     --per-table \
@@ -239,7 +255,7 @@ if [ "$MULTIREGION" = true ]; then
     --out-dir="$OUT_DIR/$PRIMARY_REGION"
 
   echo "🌍 Exporting $SECOND_REGION only..."
-  crdb-dump --verbose export \
+  $CRDB_DUMP --verbose export \
     --db="$DB_NAME" \
     --data \
     --per-table \
@@ -288,7 +304,7 @@ except ClientError as e:
 EOF
 
 echo "📤 Testing export to MinIO S3..."
-crdb-dump --verbose export \
+$CRDB_DUMP --verbose export \
   --db="$DB_NAME" \
   --data \
   --data-format=csv \
@@ -308,12 +324,12 @@ cockroach sql --insecure --host=localhost -e "
 "
 
 echo "📐 Loading schema before S3 data import..."
-crdb-dump --verbose load \
+$CRDB_DUMP --verbose load \
   --db="$DB_NAME" \
   --schema="$OUT_DIR/s3-test/$DB_NAME/${DB_NAME}_schema.sql"
 
 echo "📥 Testing import from MinIO S3..."
-crdb-dump --verbose load \
+$CRDB_DUMP --verbose load \
   --db="$DB_NAME" \
   --data-dir="$OUT_DIR/s3-test/$DB_NAME" \
   --resume-log-dir="$OUT_DIR/s3-test-resume" \

--- a/test-local.sh
+++ b/test-local.sh
@@ -5,21 +5,37 @@ set -euo pipefail
 # script -c $(cockroach demo --nodes=3 --demo-locality=region=us-east1:region=us-west1:region=us-central1 --no-example-database --empty) /dev/null >/dev/null
 #
 
-# Resolve the crdb-dump CLI: prefer the installed console script, otherwise fall
-# back to running the module directly (works as long as the package is importable,
-# e.g. after `pip install -e .` even without the console script on PATH).
+# Resolve the crdb-dump CLI. We must verify the package imports *with its
+# dependencies* (psycopg2, sqlalchemy, ...). Importing bare `crdb_dump` succeeds
+# from the source tree even when nothing is installed, so we import
+# `crdb_dump.cli`, which pulls the full dependency chain.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_can_run() { "$@" -c "import crdb_dump.cli" >/dev/null 2>&1; }
+
+# Find a Python interpreter that can import the package WITH its dependencies
+# (psycopg2, sqlalchemy, boto3, ...). boto3 is a dependency, so this interpreter
+# is also used for the inline MinIO bucket-creation snippet below.
+PYTHON=""
+for cand in "$SCRIPT_DIR/.venv/bin/python" python python3; do
+  if command -v "$cand" >/dev/null 2>&1 && _can_run "$cand"; then PYTHON="$cand"; break; fi
+done
+
 if command -v crdb-dump >/dev/null 2>&1; then
   CRDB_DUMP="crdb-dump"
-elif python -c "import crdb_dump" >/dev/null 2>&1; then
-  CRDB_DUMP="python -m crdb_dump.cli"
-elif python3 -c "import crdb_dump" >/dev/null 2>&1; then
-  CRDB_DUMP="python3 -m crdb_dump.cli"
+elif [ -n "$PYTHON" ]; then
+  CRDB_DUMP="$PYTHON -m crdb_dump.cli"
 else
-  echo "❌ crdb-dump not found. Install it first, e.g.:"
+  echo "❌ crdb-dump is not installed with its dependencies."
+  echo "   Install it (a virtualenv is recommended):"
   echo "     python -m venv .venv && source .venv/bin/activate && pip install -e ."
+  echo "   Then re-run ./test-local.sh"
   exit 1
 fi
+# Ensure we have a deps-capable interpreter for the boto3 snippet even if the
+# console script was found on PATH.
+if [ -z "$PYTHON" ]; then PYTHON="python3"; fi
 echo "🔧 Using CLI: $CRDB_DUMP"
+echo "🔧 Using Python: $PYTHON"
 
 DB_NAME="defaultdb"
 OUT_DIR="tmp/export-test"
@@ -278,7 +294,7 @@ fi
 #  minio/mc mb --ignore-existing localminio/$MINIO_BUCKET
 
 echo "🪣 Creating test bucket in MinIO via boto3..."
-python3 - <<EOF
+$PYTHON - <<EOF
 import boto3
 from botocore.exceptions import ClientError
 

--- a/test-local.sh
+++ b/test-local.sh
@@ -41,12 +41,43 @@ sleep 10
 echo "🧹 Cleaning up old output..."
 rm -rf "$OUT_DIR" logs/ "$RESUME_FILE"
 
-echo "🌍 Creating multi-region database..."
-cockroach sql --insecure --host=localhost -e "
-  DROP DATABASE IF EXISTS $DB_NAME CASCADE;
-  CREATE DATABASE $DB_NAME PRIMARY REGION 'us-east1';
-  ALTER DATABASE $DB_NAME ADD REGION 'us-west1';
-"
+echo "🔌 Checking CockroachDB is reachable on localhost:26257..."
+if ! cockroach sql --insecure --host=localhost -e "SELECT 1" >/dev/null 2>&1; then
+  echo "❌ No CockroachDB reachable on localhost:26257."
+  echo "   Start one of:"
+  echo "     • single node:  cockroach start-single-node --insecure --store=type=mem,size=1GiB"
+  echo "     • multi-region: cockroach demo --nodes=3 --demo-locality=region=us-east1:region=us-west1:region=us-central1 --no-example-database --empty"
+  exit 1
+fi
+
+# Detect whether the cluster has regions; degrade gracefully on a single node.
+CLUSTER_REGIONS=$(cockroach sql --insecure --host=localhost --format=csv \
+  -e "SELECT region FROM [SHOW REGIONS FROM CLUSTER]" 2>/dev/null | tail -n +2 || true)
+if [ -n "$CLUSTER_REGIONS" ]; then
+  MULTIREGION=true
+  PRIMARY_REGION=$(echo "$CLUSTER_REGIONS" | head -1)
+  SECOND_REGION=$(echo "$CLUSTER_REGIONS" | sed -n '2p')
+  [ -z "$SECOND_REGION" ] && SECOND_REGION="$PRIMARY_REGION"
+  echo "🌍 Multi-region cluster detected (primary=$PRIMARY_REGION, second=$SECOND_REGION)"
+else
+  MULTIREGION=false
+  echo "ℹ️  Single-region cluster — region-specific steps will be skipped"
+fi
+
+if [ "$MULTIREGION" = true ]; then
+  echo "🌍 Creating multi-region database..."
+  cockroach sql --insecure --host=localhost -e "
+    DROP DATABASE IF EXISTS $DB_NAME CASCADE;
+    CREATE DATABASE $DB_NAME PRIMARY REGION '$PRIMARY_REGION';
+    ALTER DATABASE $DB_NAME ADD REGION '$SECOND_REGION';
+  "
+else
+  echo "📦 Creating single-region database..."
+  cockroach sql --insecure --host=localhost -e "
+    DROP DATABASE IF EXISTS $DB_NAME CASCADE;
+    CREATE DATABASE $DB_NAME;
+  "
+fi
 
 echo "📐 Creating tables..."
 cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
@@ -68,11 +99,13 @@ cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
   );
 "
 
-echo "🌍 Assigning table locality..."
-cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
-  ALTER TABLE users SET LOCALITY REGIONAL BY TABLE IN 'us-east1';
-  ALTER TABLE logins SET LOCALITY REGIONAL BY TABLE IN 'us-west1';
-"
+if [ "$MULTIREGION" = true ]; then
+  echo "🌍 Assigning table locality..."
+  cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
+    ALTER TABLE users SET LOCALITY REGIONAL BY TABLE IN '$PRIMARY_REGION';
+    ALTER TABLE logins SET LOCALITY REGIONAL BY TABLE IN '$SECOND_REGION';
+  "
+fi
 
 echo "📐 Creating non-public schema objects + a VECTOR column..."
 cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
@@ -101,10 +134,9 @@ cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
   VALUES ('alice'), ('bob'), ('carol');
 "
 
-echo "📦 Exporting schema and data..."
+echo "📦 Exporting schema (full-DB DDL) and data..."
 crdb-dump --verbose export \
   --db="$DB_NAME" \
-  --per-table \
   --data \
   --data-format=csv \
   --chunk-size=1000 \
@@ -133,21 +165,30 @@ crdb-dump --verbose load \
   --dry-run \
   --print-connection
 
-echo "❌ Dropping tables to prep for reload..."
-cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
-  DROP TABLE IF EXISTS users;
-  DROP TABLE IF EXISTS logins;
+echo "❌ Dropping entire database to prep for a clean full restore..."
+cockroach sql --insecure --host=localhost -e "
+  DROP DATABASE IF EXISTS $DB_NAME CASCADE;
+  CREATE DATABASE $DB_NAME;
 "
-echo "✅ Tables dropped"
+echo "✅ Database recreated empty"
 
-echo "🧪 Full import with --validate-csv and --parallel-load"
+echo "🧪 Full restore with --validate-csv and --parallel-load"
+rm -rf "$OUT_DIR/resume-main"
 crdb-dump --verbose load \
   --db="$DB_NAME" \
   --schema="$SCHEMA_FILE" \
   --data-dir="$DATA_DIR" \
-  --resume-log="$RESUME_FILE" \
+  --resume-log-dir="$OUT_DIR/resume-main" \
   --validate-csv \
   --parallel-load
+
+echo "🔎 Verifying restored row counts..."
+for tbl in users logins cpkit.tasks embeddings; do
+  CNT=$(cockroach sql --insecure --host=localhost -d "$DB_NAME" --format=csv -e "SELECT count(*) FROM $tbl" | tail -1)
+  echo "  $tbl: $CNT rows"
+  [ "$CNT" -gt 0 ] || { echo "❌ $tbl has no rows after restore"; exit 1; }
+done
+echo "✅ Full restore verified (all tables incl. non-public schema + VECTOR)"
 
 echo "🔁 Testing data export variations..."
 for ORDER_FLAG in "" "--data-order=id" "--data-order=id --data-order-desc"; do
@@ -171,54 +212,44 @@ for ORDER_FLAG in "" "--data-order=id" "--data-order=id --data-order-desc"; do
   done
 done
 
-echo "🔍 Verifying loaded users..."
-cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "SELECT COUNT(*) FROM users"
-
-echo "🔍 Verifying loaded logins..."
-cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "SELECT COUNT(*) FROM logins"
-
-echo "🧪 Simulating failure and resuming import..."
-echo "❌ Dropping one table for partial import..."
-cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "
-  DROP TABLE IF EXISTS users;
-"
-
-echo "▶️ Running partial import to test resume..."
-crdb-dump --verbose load \
+echo "🧪 Testing resume idempotency..."
+echo "▶️ Re-running the load — every chunk should be SKIPPED (already loaded)..."
+RESUME_OUT=$(crdb-dump --verbose load \
   --db="$DB_NAME" \
   --data-dir="$DATA_DIR" \
-  --resume-log="$RESUME_FILE" \
-  --validate-csv \
-  --parallel-load
-
-echo "▶️ Resuming again — should skip already imported chunks..."
-crdb-dump --verbose load \
-  --db="$DB_NAME" \
-  --data-dir="$DATA_DIR" \
-  --resume-log="$RESUME_FILE" \
+  --resume-log-dir="$OUT_DIR/resume-main" \
   --validate-csv \
   --parallel-load \
-  --resume-strict
+  --resume-strict 2>&1)
+echo "$RESUME_OUT" | grep -E "Loaded|Skipped|Failed" | tail -8
+if echo "$RESUME_OUT" | grep -q "❌ Failed to load chunk"; then
+  echo "❌ Resume pass unexpectedly reloaded/failed chunks"; exit 1
+fi
+echo "✅ Resume idempotency verified (no chunk reloaded)"
 
-echo "🌍 Exporting us-east1 only..."
-crdb-dump --verbose export \
-  --db="$DB_NAME" \
-  --data \
-  --per-table \
-  --region="us-east1" \
-  --data-format=csv \
-  --chunk-size=1000 \
-  --out-dir="$OUT_DIR/us-east1"
+if [ "$MULTIREGION" = true ]; then
+  echo "🌍 Exporting $PRIMARY_REGION only..."
+  crdb-dump --verbose export \
+    --db="$DB_NAME" \
+    --data \
+    --per-table \
+    --region="$PRIMARY_REGION" \
+    --data-format=csv \
+    --chunk-size=1000 \
+    --out-dir="$OUT_DIR/$PRIMARY_REGION"
 
-echo "🌍 Exporting us-west1 only..."
-crdb-dump --verbose export \
-  --db="$DB_NAME" \
-  --data \
-  --per-table \
-  --region="us-west1" \
-  --data-format=csv \
-  --chunk-size=1000 \
-  --out-dir="$OUT_DIR/us-west1"
+  echo "🌍 Exporting $SECOND_REGION only..."
+  crdb-dump --verbose export \
+    --db="$DB_NAME" \
+    --data \
+    --per-table \
+    --region="$SECOND_REGION" \
+    --data-format=csv \
+    --chunk-size=1000 \
+    --out-dir="$OUT_DIR/$SECOND_REGION"
+else
+  echo "⏩ Skipping region-filtered exports (single-region cluster)"
+fi
 
 #echo "🪣 Creating test bucket in MinIO..."
 
@@ -259,7 +290,6 @@ EOF
 echo "📤 Testing export to MinIO S3..."
 crdb-dump --verbose export \
   --db="$DB_NAME" \
-  --per-table \
   --data \
   --data-format=csv \
   --chunk-size=1000 \
@@ -271,13 +301,16 @@ crdb-dump --verbose export \
   --s3-prefix="test1/" \
   --out-dir="$OUT_DIR/s3-test"
 
-echo "🧹 Dropping logins table before S3 import..."
-cockroach sql --insecure --host=localhost -d "$DB_NAME" -e "DROP TABLE IF EXISTS logins;"
+echo "🧹 Recreating empty database before S3 restore..."
+cockroach sql --insecure --host=localhost -e "
+  DROP DATABASE IF EXISTS $DB_NAME CASCADE;
+  CREATE DATABASE $DB_NAME;
+"
 
 echo "📐 Loading schema before S3 data import..."
 crdb-dump --verbose load \
   --db="$DB_NAME" \
-  --schema="$SCHEMA_FILE"
+  --schema="$OUT_DIR/s3-test/$DB_NAME/${DB_NAME}_schema.sql"
 
 echo "📥 Testing import from MinIO S3..."
 crdb-dump --verbose load \
@@ -293,6 +326,13 @@ crdb-dump --verbose load \
   --validate-csv \
   --parallel-load \
   --resume-strict
+
+echo "🔎 Verifying S3-restored row counts..."
+for tbl in users logins cpkit.tasks embeddings; do
+  CNT=$(cockroach sql --insecure --host=localhost -d "$DB_NAME" --format=csv -e "SELECT count(*) FROM $tbl" | tail -1)
+  echo "  $tbl: $CNT rows"
+  [ "$CNT" -gt 0 ] || { echo "❌ $tbl has no rows after S3 restore"; exit 1; }
+done
 
 echo "📄 Log file written to: $LOG_FILE"
 echo "✅ Done."

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -1,0 +1,34 @@
+import hashlib
+import json
+import logging
+from crdb_dump.verify.checksum import verify_checksums
+
+
+def _logger_capturing(records):
+    class ListHandler(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    logger = logging.getLogger("checksum_test")
+    logger.handlers = []
+    logger.setLevel(logging.INFO)
+    logger.addHandler(ListHandler())
+    return logger
+
+
+def test_verify_uses_three_part_manifest(tmp_path):
+    base = "cp.cpkit.tasks"
+    data_file = tmp_path / f"{base}_001.sql"
+    data_file.write_text("INSERT INTO x VALUES (1);\n")
+    h = hashlib.sha256(data_file.read_bytes()).hexdigest()
+    (tmp_path / f"{base}.manifest.json").write_text(json.dumps(
+        {"table": base, "region": "N/A",
+         "chunks": [{"file": f"{base}_001.sql", "rows": 1, "sha256": h}]}))
+
+    records = []
+    opts = {"tables": "cp.cpkit.tasks", "db": "cp", "retry_count": 1, "retry_delay": 0}
+    verify_checksums(opts, str(tmp_path), _logger_capturing(records))
+
+    joined = "\n".join(records)
+    assert "No manifest found" not in joined
+    assert "Verified" in joined

--- a/tests/test_collect_objects.py
+++ b/tests/test_collect_objects.py
@@ -1,0 +1,37 @@
+import logging
+from unittest.mock import MagicMock
+from crdb_dump.export.schema import collect_objects
+from crdb_dump.utils.common import get_table_locality
+
+
+def test_collect_tables_includes_non_public_schema():
+    # SHOW TABLES rows: (schema_name, table_name, type, owner, est_rows, locality)
+    rows = [
+        ("public", "users", "table", "root", 0, None),
+        ("cpkit", "tasks", "table", "root", 0, None),
+    ]
+    eng = MagicMock()
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    conn.execute.side_effect = [None, iter(rows)]  # USE db, then SHOW TABLES
+    eng.connect.return_value = conn
+    result = collect_objects(eng, "cp", "table", logging.getLogger("t"), 1, 0.0)
+    assert "cp.public.users" in result
+    assert "cp.cpkit.tasks" in result
+
+
+def test_locality_map_keyed_by_three_part():
+    rows = [
+        ("public", "users", "table", "root", 0, "REGIONAL BY TABLE IN us-east1"),
+        ("cpkit", "tasks", "table", "root", 0, None),
+    ]
+    eng = MagicMock()
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    conn.execute.side_effect = [None, iter(rows)]
+    eng.connect.return_value = conn
+    m = get_table_locality(eng, "cp", logging.getLogger("t"))
+    assert m["cp.public.users"] == "REGIONAL BY TABLE IN us-east1"
+    assert m["cp.cpkit.tasks"] == "N/A"

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1,0 +1,35 @@
+import json
+import os
+import logging
+from unittest.mock import MagicMock
+from crdb_dump.export import data as data_mod
+
+
+def test_export_table_data_three_part_naming(tmp_path):
+    cols = [("id",), ("name",)]
+    page1 = [(1, "a"), (2, "b")]
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    # 1) column query, 2) first page, 3) empty page
+    conn.execute.side_effect = [
+        iter(cols),
+        MagicMock(fetchall=lambda: page1),
+        MagicMock(fetchall=lambda: []),
+    ]
+    engine = MagicMock()
+    engine.connect.return_value = conn
+
+    total = data_mod.export_table_data(
+        engine, "cp.cpkit.tasks", str(tmp_path), "sql", False, None, False,
+        None, False, 1000, False, logging.getLogger("t"), {}, 1, 0.0, {})
+
+    assert total == 2
+    files = os.listdir(tmp_path)
+    assert any(f.startswith("cp.cpkit.tasks_001") and f.endswith(".sql") for f in files)
+    manifest = json.load(open(tmp_path / "cp.cpkit.tasks.manifest.json"))
+    assert manifest["table"] == "cp.cpkit.tasks"
+    # The generated INSERT must use the fully-qualified quoted name.
+    sql_file = [f for f in files if f.endswith(".sql")][0]
+    content = (tmp_path / sql_file).read_text()
+    assert 'INSERT INTO "cp"."cpkit"."tasks"' in content

--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -1,0 +1,24 @@
+from crdb_dump.utils import db_connection as dbc
+
+
+def test_psycopg_uses_opts_when_no_env(monkeypatch):
+    monkeypatch.delenv("CRDB_URL", raising=False)
+    captured = {}
+
+    def fake_connect(dsn):
+        captured["dsn"] = dsn
+        return "CONN"
+
+    monkeypatch.setattr(dbc.psycopg2, "connect", fake_connect)
+    conn = dbc.get_psycopg_connection({"host": "h1", "port": 5432, "db": "cp"})
+    assert conn == "CONN"
+    assert "h1" in captured["dsn"] and "cp" in captured["dsn"]
+
+
+def test_psycopg_prefers_env(monkeypatch):
+    monkeypatch.setenv("CRDB_URL", "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable")
+    captured = {}
+    monkeypatch.setattr(dbc.psycopg2, "connect",
+                        lambda dsn: captured.setdefault("dsn", dsn) or "C")
+    dbc.get_psycopg_connection({"host": "ignored"})
+    assert captured["dsn"].startswith("postgresql://")

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,0 +1,45 @@
+import pytest
+from crdb_dump.utils.identifiers import ObjectName, quote_ident, parse_object_name
+
+
+def test_quote_ident_simple():
+    assert quote_ident("users") == '"users"'
+
+
+def test_quote_ident_escapes_embedded_quote():
+    assert quote_ident('we"ird') == '"we""ird"'
+
+
+def test_quote_ident_mixed_case_preserved():
+    assert quote_ident("MyTable") == '"MyTable"'
+
+
+def test_parse_three_part():
+    o = parse_object_name("cp.cpkit.tasks", default_db="ignored")
+    assert (o.database, o.schema, o.table) == ("cp", "cpkit", "tasks")
+
+
+def test_parse_two_part_is_schema_table():
+    o = parse_object_name("cpkit.tasks", default_db="cp")
+    assert (o.database, o.schema, o.table) == ("cp", "cpkit", "tasks")
+
+
+def test_parse_one_part_defaults_public():
+    o = parse_object_name("tasks", default_db="cp")
+    assert (o.database, o.schema, o.table) == ("cp", "public", "tasks")
+
+
+def test_fq_quoted():
+    o = ObjectName("cp", "cpkit", "tasks")
+    assert o.fq_quoted() == '"cp"."cpkit"."tasks"'
+
+
+def test_fq_plain_and_file_base():
+    o = ObjectName("cp", "cpkit", "tasks")
+    assert o.fq_plain() == "cp.cpkit.tasks"
+    assert o.file_base() == "cp.cpkit.tasks"
+
+
+def test_parse_rejects_four_parts():
+    with pytest.raises(ValueError):
+        parse_object_name("a.b.c.d", default_db="cp")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -141,6 +141,48 @@ def test_non_public_schema_roundtrip(tmp_path):
 
 @pytest.mark.integration
 @pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_bytes_csv_roundtrip(tmp_path):
+    """BYTES values must survive a full CSV export/load round-trip (bytea hex)."""
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS bcsv")
+    cur.execute("CREATE TABLE bcsv (id INT PRIMARY KEY, v BYTES)")
+    cur.execute("INSERT INTO bcsv VALUES (1, %s), (2, %s)", (b'\x01\x02', b'\xff'))
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    out = tmp_path / "bout"
+    runner = CliRunner()
+    r = runner.invoke(main, [
+        "export", "--db=defaultdb", "--tables=public.bcsv",
+        "--per-table", "--data", "--data-format=csv", f"--out-dir={out}"])
+    assert r.exit_code == 0, r.output
+
+    db_dir = out / "defaultdb"
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM bcsv")
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    r = runner.invoke(main, [
+        "load", "--db=defaultdb", f"--data-dir={db_dir}", "--validate-csv",
+        f"--resume-log-dir={tmp_path}/resume"])
+    assert r.exit_code == 0, r.output
+
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT encode(v, 'hex') FROM bcsv ORDER BY id")
+    vals = [row[0] for row in cur.fetchall()]
+    assert vals == ["0102", "ff"]
+    cur.close()
+    conn.close()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
 def test_vector_roundtrip(tmp_path):
     """VECTOR values must survive a full CSV export/load round-trip."""
     conn = get_psycopg_connection()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,10 +8,8 @@ from crdb_dump.utils.db_connection import get_psycopg_connection
 @pytest.mark.integration
 @pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
 def test_export_users_schema_sql(tmp_path):
-
     conn = get_psycopg_connection()
     cur = conn.cursor()
-
     cur.execute("DROP TABLE IF EXISTS users")
     cur.execute("""
         CREATE TABLE users (
@@ -39,18 +37,17 @@ def test_export_users_schema_sql(tmp_path):
     assert result.exit_code == 0
 
     db_subdir = dump_dir / "defaultdb"
-    ddl_files = list(db_subdir.glob("table_users*.sql"))
+    ddl_files = list(db_subdir.glob("table_defaultdb.public.users*.sql"))
     assert ddl_files, f"No schema file found for users table in {db_subdir}"
     ddl_contents = ddl_files[0].read_text()
     assert "CREATE TABLE" in ddl_contents
 
+
 @pytest.mark.integration
 @pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
 def test_export_users_bytes_data_sql(tmp_path):
-
     conn = get_psycopg_connection()
     cur = conn.cursor()
-
     cur.execute("DROP TABLE IF EXISTS users")
     cur.execute("""
         CREATE TABLE users (
@@ -74,6 +71,7 @@ def test_export_users_bytes_data_sql(tmp_path):
     result = runner.invoke(main, [
         "export",
         "--db=defaultdb",
+        "--tables=public.users",
         "--data",
         "--data-format=sql",
         "--per-table",
@@ -84,9 +82,103 @@ def test_export_users_bytes_data_sql(tmp_path):
     assert result.exit_code == 0
 
     db_subdir = dump_dir / "defaultdb"
-    data_files = list(db_subdir.glob("users*data.sql"))
+    data_files = list(db_subdir.glob("defaultdb.public.users_*.sql"))
     assert data_files, f"No data SQL file found for users table in {db_subdir}"
     contents = data_files[0].read_text()
 
     assert "decode('0102', 'hex')" in contents
     assert "decode('0304', 'hex')" in contents
+
+
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_non_public_schema_roundtrip(tmp_path):
+    """Export and reload a table in a non-public schema (the reported bug)."""
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("CREATE SCHEMA IF NOT EXISTS cpkit")
+    cur.execute("DROP TABLE IF EXISTS cpkit.tasks")
+    cur.execute("CREATE TABLE cpkit.tasks (id INT PRIMARY KEY, name STRING)")
+    cur.execute("INSERT INTO cpkit.tasks VALUES (1, 'a'), (2, 'b')")
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    out = tmp_path / "out"
+    runner = CliRunner()
+    r = runner.invoke(main, [
+        "export", "--db=defaultdb", "--tables=cpkit.tasks",
+        "--per-table", "--data", "--data-format=csv", f"--out-dir={out}"])
+    assert r.exit_code == 0, r.output
+
+    db_dir = out / "defaultdb"
+    assert (db_dir / "defaultdb.cpkit.tasks.manifest.json").exists(), \
+        f"manifest missing; files: {list(db_dir.iterdir())}"
+    schema_file = db_dir / "table_defaultdb.cpkit.tasks.sql"
+    assert schema_file.exists(), f"schema file missing; files: {list(db_dir.iterdir())}"
+
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("DROP TABLE cpkit.tasks")
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    r = runner.invoke(main, [
+        "load", "--db=defaultdb",
+        f"--schema={schema_file}",
+        f"--data-dir={db_dir}", "--validate-csv",
+        f"--resume-log-dir={tmp_path}/resume"])
+    assert r.exit_code == 0, r.output
+
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT count(*) FROM cpkit.tasks")
+    assert cur.fetchone()[0] == 2
+    cur.close()
+    conn.close()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_vector_roundtrip(tmp_path):
+    """VECTOR values must survive a full CSV export/load round-trip."""
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS vroundtrip")
+    cur.execute("CREATE TABLE vroundtrip (id INT PRIMARY KEY, embd VECTOR(3))")
+    cur.execute("INSERT INTO vroundtrip VALUES (1, '[1.5,2,3.25]'), (2, '[0,0,0]')")
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    out = tmp_path / "vout"
+    runner = CliRunner()
+    r = runner.invoke(main, [
+        "export", "--db=defaultdb", "--tables=public.vroundtrip",
+        "--per-table", "--data", "--data-format=csv", f"--out-dir={out}"])
+    assert r.exit_code == 0, r.output
+
+    db_dir = out / "defaultdb"
+    schema_file = db_dir / "table_defaultdb.public.vroundtrip.sql"
+    assert "VECTOR(3)" in schema_file.read_text()
+
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM vroundtrip")
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    r = runner.invoke(main, [
+        "load", "--db=defaultdb", f"--data-dir={db_dir}", "--validate-csv",
+        f"--resume-log-dir={tmp_path}/resume"])
+    assert r.exit_code == 0, r.output
+
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT embd::STRING FROM vroundtrip ORDER BY id")
+    vals = [row[0] for row in cur.fetchall()]
+    assert vals == ["[1.5,2,3.25]", "[0,0,0]"]
+    cur.close()
+    conn.close()

--- a/tests/test_io_names.py
+++ b/tests/test_io_names.py
@@ -1,0 +1,23 @@
+import pytest
+from crdb_dump.utils.io import validate_fq_table_names, normalize_filename
+
+
+def test_accepts_schema_table_and_normalizes():
+    assert validate_fq_table_names(["cpkit.tasks"], "cp") == ["cp.cpkit.tasks"]
+
+
+def test_accepts_full_three_part():
+    assert validate_fq_table_names(["cp.cpkit.tasks"], "cp") == ["cp.cpkit.tasks"]
+
+
+def test_bare_table_defaults_public():
+    assert validate_fq_table_names(["tasks"], "cp") == ["cp.public.tasks"]
+
+
+def test_rejects_wrong_db_prefix():
+    with pytest.raises(ValueError):
+        validate_fq_table_names(["other.cpkit.tasks"], "cp")
+
+
+def test_normalize_filename_keeps_three_part():
+    assert normalize_filename("TABLE", "cp.cpkit.tasks") == "table_cp.cpkit.tasks.sql"

--- a/tests/test_load_schema_split.py
+++ b/tests/test_load_schema_split.py
@@ -1,0 +1,14 @@
+from crdb_dump.loader.loader import _split_sql_statements
+
+
+def test_split_ignores_semicolons_in_string_literals():
+    sql = "INSERT INTO t VALUES ('a;b'); CREATE TABLE x (id INT);"
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 2
+    assert "a;b" in stmts[0]
+
+
+def test_split_drops_trailing_semicolons_and_blanks():
+    sql = "CREATE TABLE a (id INT);\n\n;  ; CREATE TABLE b (id INT);\n"
+    stmts = _split_sql_statements(sql)
+    assert stmts == ["CREATE TABLE a (id INT)", "CREATE TABLE b (id INT)"]

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -1,0 +1,45 @@
+import logging
+from unittest.mock import MagicMock
+from crdb_dump.export.schema import dump_all_ddl, dump_create_statement
+
+
+def _conn_with(execute_results):
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    conn.execute.side_effect = execute_results
+    return conn
+
+
+def test_dump_all_ddl_types_then_tables():
+    conn = _conn_with([
+        None,                                                       # USE db
+        iter([("CREATE TYPE cpkit.status AS ENUM ('a');",)]),        # SHOW CREATE ALL TYPES
+        iter([("CREATE TABLE cpkit.tasks (id INT8 PRIMARY KEY);",)]),  # SHOW CREATE ALL TABLES
+    ])
+    eng = MagicMock()
+    eng.connect.return_value = conn
+    out = dump_all_ddl(eng, "cp", logging.getLogger("t"), 1, 0.0)
+    assert "CREATE TYPE cpkit.status" in out
+    assert "CREATE TABLE cpkit.tasks" in out
+    assert out.index("CREATE TYPE") < out.index("CREATE TABLE cpkit.tasks")
+
+
+def test_dump_create_statement_uses_quoted_fq_name():
+    captured = {"stmts": []}
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+
+    def execute(stmt, *a, **k):
+        captured["stmts"].append(str(stmt))
+        if "USE" in str(stmt):
+            return None
+        return iter([("tasks", "CREATE TABLE cpkit.tasks (id INT8 PRIMARY KEY)")])
+
+    conn.execute.side_effect = execute
+    eng = MagicMock()
+    eng.connect.return_value = conn
+    ddl = dump_create_statement(eng, "TABLE", "cp.cpkit.tasks", logging.getLogger("t"), 1, 0.0)
+    assert ddl.strip().endswith(";")
+    assert any('"cp"."cpkit"."tasks"' in s for s in captured["stmts"])

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -11,18 +11,22 @@ def _conn_with(execute_results):
     return conn
 
 
-def test_dump_all_ddl_types_then_tables():
+def test_dump_all_ddl_schemas_types_then_tables():
     conn = _conn_with([
         None,                                                       # USE db
+        iter([("public",), ("cpkit",)]),                            # SHOW SCHEMAS
         iter([("CREATE TYPE cpkit.status AS ENUM ('a');",)]),        # SHOW CREATE ALL TYPES
         iter([("CREATE TABLE cpkit.tasks (id INT8 PRIMARY KEY);",)]),  # SHOW CREATE ALL TABLES
     ])
     eng = MagicMock()
     eng.connect.return_value = conn
     out = dump_all_ddl(eng, "cp", logging.getLogger("t"), 1, 0.0)
+    assert 'CREATE SCHEMA IF NOT EXISTS "cpkit"' in out
+    assert "CREATE SCHEMA IF NOT EXISTS \"public\"" not in out  # system schema skipped
     assert "CREATE TYPE cpkit.status" in out
     assert "CREATE TABLE cpkit.tasks" in out
-    assert out.index("CREATE TYPE") < out.index("CREATE TABLE cpkit.tasks")
+    # Ordering: schema -> type -> table.
+    assert out.index("CREATE SCHEMA") < out.index("CREATE TYPE") < out.index("CREATE TABLE cpkit.tasks")
 
 
 def test_dump_create_statement_uses_quoted_fq_name():

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -49,10 +49,11 @@ def test_cli_missing_db():
     assert "--db" in result.output
 
 def test_csv_literal_bytes():
-    assert to_csv_literal(b"\x01\x02") == "0102"
+    # bytea hex format so COPY ... WITH CSV decodes back to bytes
+    assert to_csv_literal(b"\x01\x02") == r"\x0102"
 
 def test_csv_literal_memoryview():
-    assert to_csv_literal(memoryview(b"\x03\x04")) == "0304"
+    assert to_csv_literal(memoryview(b"\x03\x04")) == r"\x0304"
 
 def test_csv_literal_string():
     assert to_csv_literal("hello") == "hello"

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,18 @@
+"""Regression tests for CockroachDB VECTOR support.
+
+CockroachDB returns VECTOR values as strings like '[1.5,2,3.25]' from both
+SQLAlchemy and psycopg2. Our literal encoders must preserve that string
+verbatim (NOT treat it as a Postgres array). If a future driver starts
+returning Python lists for VECTOR, the data-export integration test will
+catch the regression.
+"""
+from crdb_dump.utils.common import to_sql_literal, to_csv_literal
+
+
+def test_sql_literal_preserves_vector_string():
+    assert to_sql_literal("[1.5,2,3.25]") == "'[1.5,2,3.25]'"
+
+
+def test_csv_literal_preserves_vector_string():
+    # Returned verbatim; csv.writer adds quoting for the embedded commas.
+    assert to_csv_literal("[1.5,2,3.25]") == "[1.5,2,3.25]"


### PR DESCRIPTION
## Summary

Fixes the reported bug where objects **not in the `public` schema** were not exported/restored, and does a broader correctness + best-practices pass. CockroachDB objects are three-part `database.schema.table`; the codebase assumed two-part `database.table` throughout.

## Key changes

- **Canonical identifier model** (`crdb_dump/utils/identifiers.py`): one place for parsing/qualifying/quoting object names. Eliminates schema-dropping, SQL-injection via interpolated identifiers, and mixed-case/reserved-word breakage.
- **Schema export**: full-DB dumps now use native `SHOW CREATE ALL TYPES` / `SHOW CREATE ALL TABLES` (dependency-ordered, FK constraints validated post-load), and emit `CREATE SCHEMA IF NOT EXISTS` for user schemas so a fresh-DB restore works. Selective export uses schema-aware per-object `SHOW CREATE`.
- **Data export**: schema-aware column queries; three-part file/manifest naming (`db.schema.table_NNN.csv|sql`, `db.schema.table.manifest.json`).
- **Loader**: honors `--host/--port/--certs-dir` (previously ignored); schema-aware `COPY`/CSV validation; `sqlparse`-based statement splitting.

## Bugs fixed along the way

- Data exporter **crashed** on three-part names (`db, tbl = table.split('.')`).
- **BYTES via CSV were corrupted** — now encoded as bytea hex (`\x...`).
- `import click` missing → `NameError` when `--tables` + `--exclude-tables`.
- Schema file appended (duplicated DDL) on re-run.
- Selective data export misread first name segment as the database.
- Deprecated `datetime.utcnow()`.

## Types

- BYTES, UUID, ARRAY, enums, and **VECTOR** verified round-tripping (SQL + CSV).

## Packaging

- Python **3.10+**, version **0.4.0**, deps upgraded to latest GA, `sqlparse` added, `CHANGELOG.md`, repo hygiene (untrack `build/`/`dist/`), CI split into 3.10–3.13 unit matrix + integration job.

## Breaking

Three-part naming for filenames/manifests/resume keys and `--tables` input (two-part now means `schema.table`). See `CHANGELOG.md`.

## Testing

- Unit: 45 tests (identifiers, schema/data export, io names, db connection, sqlparse split, checksum, vector).
- Integration (live CRDB v25.4): non-public schema, VECTOR, BYTES-CSV, users schema/bytes round-trips — all green.
- E2E: `test-local.sh` (now region-aware, single- or multi-region) runs clean end-to-end incl. MinIO/S3 — full restore, resume idempotency, and S3 restore all verified.