### PR TITLE
Add PyPI release workflow (Trusted Publishing) and fix README badges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, e.g. 0.4.0 (must match the version in pyproject.toml)"
+        required: true
+
+permissions:
+  contents: write   # create the GitHub Release
+  id-token: write   # OIDC for PyPI Trusted Publishing
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" build
+
+      - name: Verify version matches pyproject.toml
+        run: |
+          PKG_VERSION=$(python -c "import importlib.metadata as m; print(m.version('crdb-dump'))")
+          echo "package version: $PKG_VERSION  |  requested: ${{ inputs.version }}"
+          if [ "$PKG_VERSION" != "${{ inputs.version }}" ]; then
+            echo "::error::Version mismatch: pyproject.toml is $PKG_VERSION but you requested ${{ inputs.version }}. Bump the version in pyproject.toml (and CHANGELOG.md) first."
+            exit 1
+          fi
+
+      - name: Start CockroachDB (single node)
+        run: |
+          docker run -d --name crdb -p 26257:26257 -p 8080:8080 \
+            cockroachdb/cockroach:latest-v25.4 start-single-node --insecure
+          for i in $(seq 1 30); do
+            if docker exec crdb ./cockroach sql --insecure -e "SELECT 1" >/dev/null 2>&1; then
+              echo "CockroachDB ready"; break
+            fi
+            echo "waiting for crdb..."; sleep 2
+          done
+
+      - name: Run full test suite
+        env:
+          CRDB_URL: cockroachdb://root@localhost:26257/defaultdb?sslmode=disable
+        run: pytest -ra -q
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          name: v${{ inputs.version }}
+          generate_release_notes: true
+          files: |
+            dist/*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-[![PyPI version](https://img.shields.io/pypi/v/crdb-dump)](https://pypi.org/project/crdb-dump/)
-[![Python versions](https://img.shields.io/pypi/pyversions/crdb-dump)](https://pypi.org/project/crdb-dump/)
-[![License](https://img.shields.io/pypi/l/crdb-dump)](https://pypi.org/project/crdb-dump/)
-[![Build status](https://github.com/viragtripathi/crdb-dump/actions/workflows/python-ci.yml/badge.svg)](https://github.com/viragtripathi/crdb-dump/actions)
+[![Tests](https://github.com/viragtripathi/crdb-dump/actions/workflows/python-ci.yml/badge.svg)](https://github.com/viragtripathi/crdb-dump/actions/workflows/python-ci.yml)
+[![PyPI version](https://badge.fury.io/py/crdb-dump.svg)](https://badge.fury.io/py/crdb-dump)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Downloads](https://static.pepy.tech/badge/crdb-dump/month)](https://pepy.tech/project/crdb-dump)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 # crdb-dump
 
@@ -270,6 +271,27 @@ pytest -m integration
 # Full end-to-end (needs cockroach + Docker/MinIO)
 ./test-local.sh
 ```
+
+---
+
+## 🚀 Releasing (maintainers)
+
+Releases publish to PyPI via the **Release** GitHub Action
+(`.github/workflows/release.yml`) using PyPI **Trusted Publishing** (OIDC) — no
+API tokens stored in the repo.
+
+One-time setup on PyPI: add a Trusted Publisher for the `crdb-dump` project →
+owner `viragtripathi`, repository `crdb-dump`, workflow `release.yml`.
+
+To cut a release:
+
+1. Bump `version` in `pyproject.toml` and update `CHANGELOG.md`; merge to `main`.
+2. Run the **Release** workflow (Actions → Release → *Run workflow*) and enter the
+   same version (e.g. `0.4.0`).
+
+The workflow verifies the input matches the packaged version, runs the full test
+suite against a CockroachDB container, builds the sdist/wheel, publishes to PyPI,
+and creates a `v<version>` GitHub Release with auto-generated notes.
 
 ---
 


### PR DESCRIPTION
## Summary

- **`/.github/workflows/release.yml`** — a manual (`workflow_dispatch`) release workflow modeled on `langchain-cockroachdb`, using PyPI **Trusted Publishing** (OIDC, `pypa/gh-action-pypi-publish`) so no API token is stored in the repo. It verifies the requested version matches `pyproject.toml`, runs the full test suite against a CockroachDB container, builds the sdist/wheel, publishes to PyPI, and creates a `v<version>` GitHub Release with auto-generated notes.
- **README badges** — replaced the dynamic `pypi/pyversions` badge (which reads *published* PyPI metadata and was stuck showing the old 0.3.0 / Python 3.7–3.10 info) with an accurate static `Python 3.10+` badge, and aligned the badge set with `langchain-cockroachdb` (Tests, PyPI version, Python 3.10+, Downloads, License: MIT).
- **README "Releasing" section** — documents the one-time PyPI Trusted Publisher setup and the release steps.

## One-time prerequisite

On PyPI, add a Trusted Publisher for project `crdb-dump`: owner `viragtripathi`, repo `crdb-dump`, workflow `release.yml`. (Until then, the publish step will fail to authenticate.)

## Verification

- Both workflow YAMLs parse.
- `python -m build` produces `crdb_dump-0.4.0` sdist + wheel.
- Version-guard logic confirmed against the installed package version (0.4.0).
- Full test suite green (50 unit + integration).

The actual PyPI publish step can only be fully exercised by running the workflow after the Trusted Publisher is configured.