### PR TITLE
Add MkDocs documentation site (GitHub Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Docs
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "crdb_dump/**"
+      - "CHANGELOG.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      - name: Build (strict) and deploy
+        run: |
+          mkdocs build --strict
+          mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ resume/
 # cockroach single-node aux output
 heap_profiler/
 cockroach-data/
+site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.4.0 (unreleased)
+## Unreleased
+
+_No changes yet._
+
+## 0.4.0 — 2026-06-26
 
 ### Breaking
 - Object naming is now three-part `database.schema.table` everywhere

--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Downloads](https://static.pepy.tech/badge/crdb-dump/month)](https://pepy.tech/project/crdb-dump)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue.svg)](https://viragtripathi.github.io/crdb-dump/)
 
 # crdb-dump
 
 A feature-rich CLI for exporting and importing CockroachDB schemas and data. Includes support for parallel chunked exports, manifest checksums, BYTES/UUID/ARRAY/VECTOR types, multi-schema (non-`public`) objects, permission introspection, secure resumable imports, S3-compatible storage (MinIO, Cohesity), region-aware filtering, and automatic retry logic.
 
 > **Requires Python 3.10+.**
+
+📖 **Documentation:** https://viragtripathi.github.io/crdb-dump/
 
 > ### ⚠️ Breaking changes in 0.4.0
 > - All object names are now three-part `database.schema.table` (filenames,

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+--8<-- "CHANGELOG.md"

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -1,0 +1,5 @@
+# License
+
+crdb-dump is released under the MIT License.
+
+--8<-- "LICENSE"

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,0 +1,22 @@
+# Contributing
+
+Pull requests are welcome — star ⭐ the repo, file issues, or propose features at
+<https://github.com/viragtripathi/crdb-dump/issues>.
+
+## Development setup
+
+```bash
+git clone https://github.com/viragtripathi/crdb-dump
+cd crdb-dump
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## Before opening a PR
+
+- Run unit tests: `pytest -m "not integration"`
+- If your change touches export/import behavior, run the integration and
+  end-to-end suites too — see [Testing](testing.md).
+- Keep commit messages plain and descriptive.
+
+For releases, see [Releasing](releasing.md).

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -14,8 +14,11 @@ On PyPI, add a Trusted Publisher for the `crdb-dump` project:
 
 ## Cutting a release
 
-1. Bump `version` in `pyproject.toml` and update `CHANGELOG.md`; merge to `main`.
-2. Run **Actions → Release → Run workflow** and enter the same version (e.g. `0.4.0`).
+1. Bump `version` in `pyproject.toml`.
+2. In `CHANGELOG.md`, rename the `## Unreleased` section to `## <version> — <YYYY-MM-DD>`
+   and add a fresh empty `## Unreleased` section above it.
+3. Merge to `main`.
+4. Run **Actions → Release → Run workflow** and enter the same version (e.g. `0.4.0`).
 
 The workflow verifies the input matches the packaged version, runs the full test
 suite against a CockroachDB container, builds the sdist/wheel, publishes to PyPI,

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -1,0 +1,22 @@
+# Releasing
+
+Releases publish to PyPI via the **Release** GitHub Action
+(`.github/workflows/release.yml`) using PyPI **Trusted Publishing** (OIDC) — no
+API tokens are stored in the repo.
+
+## One-time setup
+
+On PyPI, add a Trusted Publisher for the `crdb-dump` project:
+
+- Owner: `viragtripathi`
+- Repository: `crdb-dump`
+- Workflow: `release.yml`
+
+## Cutting a release
+
+1. Bump `version` in `pyproject.toml` and update `CHANGELOG.md`; merge to `main`.
+2. Run **Actions → Release → Run workflow** and enter the same version (e.g. `0.4.0`).
+
+The workflow verifies the input matches the packaged version, runs the full test
+suite against a CockroachDB container, builds the sdist/wheel, publishes to PyPI,
+and creates a `v<version>` GitHub Release with auto-generated notes.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,33 @@
+# Testing
+
+crdb-dump is tested at three levels. Requires Python 3.10+.
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## Unit tests (no database)
+
+```bash
+pytest -m "not integration"
+```
+
+## Integration tests (need a reachable CockroachDB)
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+pytest -m integration
+```
+
+Integration tests cover non-`public` schema, `VECTOR`, and `BYTES` round-trips.
+
+## End-to-end
+
+```bash
+./test-local.sh
+```
+
+The script auto-detects a single- or multi-region cluster, exercises export →
+verify → restore → resume, and an S3 (MinIO) round-trip. It resolves the CLI from
+the repo `.venv` automatically.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,33 @@
+# Configuration
+
+## Connection
+
+crdb-dump connects via the `CRDB_URL` environment variable (preferred), otherwise
+it defaults to `localhost:26257`:
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/mydb?sslmode=disable"
+# postgresql:// URLs are also accepted and normalized automatically
+export CRDB_URL="postgresql://root@host:26257/mydb?sslmode=disable"
+```
+
+### TLS / secure clusters
+
+When `CRDB_URL` is not set, you can point at a certificates directory:
+
+```bash
+crdb-dump export --db=mydb --certs-dir ~/certs
+```
+
+This connects with `sslmode=verify-full` using `ca.crt`, `client.root.crt`, and
+`client.root.key` from that directory.
+
+Use `--print-connection` to print the resolved connection URL (credentials
+redacted) and exit.
+
+## S3 / object storage
+
+S3 credentials can be supplied via flags or the standard AWS environment
+variables `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. See
+[S3-Compatible Storage](../guides/s3-storage.md) for the full set of options
+(custom endpoints for MinIO and Cohesity, bucket, prefix).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,22 @@
+# Installation
+
+```bash
+pip install crdb-dump
+```
+
+Requires **Python 3.10+**.
+
+## From source (development)
+
+```bash
+git clone https://github.com/viragtripathi/crdb-dump
+cd crdb-dump
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Verify the install:
+
+```bash
+crdb-dump version
+```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,38 @@
+# Quick Start
+
+## 1. Point at a cluster
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/mydb?sslmode=disable"
+```
+
+## 2. Export schema + data
+
+```bash
+crdb-dump export --db=mydb --data --data-format=csv --chunk-size=1000
+```
+
+Output lands under `crdb_dump_output/mydb/`:
+
+- `mydb_schema.sql` — full DDL (dependency-ordered, with `CREATE SCHEMA` for
+  non-`public` schemas)
+- `mydb.<schema>.<table>_NNN.csv` — chunked data
+- `mydb.<schema>.<table>.manifest.json` — checksummed chunk manifest
+
+## 3. Restore
+
+```bash
+crdb-dump load --db=mydb \
+  --schema=crdb_dump_output/mydb/mydb_schema.sql \
+  --data-dir=crdb_dump_output/mydb \
+  --validate-csv
+```
+
+## 4. Verify checksums
+
+```bash
+crdb-dump export --db=mydb --verify
+```
+
+Next: read the [Guides](../guides/export-schema.md) for the full feature set, or
+the [CLI Reference](../reference/cli.md) for every option.

--- a/docs/guides/export-data.md
+++ b/docs/guides/export-data.md
@@ -1,0 +1,53 @@
+# Exporting Data
+
+Add `--data` to export table data alongside (or instead of) schema.
+
+## Formats
+
+```bash
+crdb-dump export --db=mydb --data --data-format=csv    # chunked CSV (default)
+crdb-dump export --db=mydb --data --data-format=sql    # INSERT statements
+```
+
+## Chunking
+
+Rows are written in chunks; each chunk is a separate file plus an entry in the
+table's manifest.
+
+```bash
+crdb-dump export --db=mydb --data --data-format=csv --chunk-size=1000
+```
+
+Files are named `mydb.<schema>.<table>_NNN.csv`. Each table also gets a
+`mydb.<schema>.<table>.manifest.json` recording every chunk's row count and
+SHA-256 checksum.
+
+## Compression
+
+```bash
+crdb-dump export --db=mydb --data --data-format=csv --data-compress   # .csv.gz
+```
+
+## Ordering
+
+```bash
+crdb-dump export --db=mydb --data --data-order=id
+crdb-dump export --db=mydb --data --data-order=id --data-order-desc
+# Fail (instead of warn) if an ordered column is missing:
+crdb-dump export --db=mydb --data --data-order=id --data-order-strict
+```
+
+## Parallelism and limits
+
+```bash
+crdb-dump export --db=mydb --data --data-parallel      # export tables concurrently
+crdb-dump export --db=mydb --data --data-limit=100000  # cap rows per table
+```
+
+## Verifying
+
+Re-run with `--verify` to validate each chunk against its manifest checksum:
+
+```bash
+crdb-dump export --db=mydb --verify
+```

--- a/docs/guides/export-schema.md
+++ b/docs/guides/export-schema.md
@@ -1,0 +1,54 @@
+# Exporting Schema
+
+By default, `crdb-dump export` writes the full database DDL to
+`crdb_dump_output/<db>/<db>_schema.sql`.
+
+## Full-database DDL
+
+For a whole-database export, crdb-dump uses CockroachDB's native bulk DDL:
+
+```bash
+crdb-dump export --db=mydb
+```
+
+It emits, in dependency order:
+
+1. `CREATE SCHEMA IF NOT EXISTS` for every non-`public` schema,
+2. `SHOW CREATE ALL TYPES` (enums),
+3. `SHOW CREATE ALL TABLES` (sequences → tables → views, with foreign-key
+   constraints split into trailing `ALTER TABLE ... ADD CONSTRAINT ... VALIDATE`).
+
+This makes the resulting `mydb_schema.sql` safe to replay into a fresh database.
+
+## Output formats
+
+```bash
+crdb-dump export --db=mydb --format sql     # default
+crdb-dump export --db=mydb --format json
+crdb-dump export --db=mydb --format yaml
+```
+
+## One file per object
+
+```bash
+crdb-dump export --db=mydb --per-table
+# e.g. table_mydb.public.users.sql, type_mydb.public.status.sql
+```
+
+## Selecting objects
+
+```bash
+# Include specific objects (table / schema.table / db.schema.table)
+crdb-dump export --db=mydb --tables=public.users,cpkit.tasks
+
+# Exclude specific objects
+crdb-dump export --db=mydb --exclude-tables=public.audit_log
+```
+
+See the [Naming Model](../reference/naming-model.md) for how names are
+interpreted.
+
+## Permissions
+
+Add roles, grants, and role memberships with `--include-permissions` — see
+[Permissions](permissions.md).

--- a/docs/guides/import-restore.md
+++ b/docs/guides/import-restore.md
@@ -1,0 +1,52 @@
+# Importing & Restoring
+
+`crdb-dump load` applies schema and loads data via CockroachDB `COPY`.
+
+## Schema + data
+
+```bash
+crdb-dump load --db=mydb \
+  --schema=crdb_dump_output/mydb/mydb_schema.sql \
+  --data-dir=crdb_dump_output/mydb \
+  --validate-csv
+```
+
+- `--schema` applies a `.sql` DDL file (statements are split safely, respecting
+  string literals and function bodies).
+- `--data-dir` loads every `*.manifest.json` found in the directory.
+- `--validate-csv` checks each chunk's header against the live table columns
+  before loading.
+
+## Parallel loading
+
+```bash
+crdb-dump load --db=mydb --data-dir=crdb_dump_output/mydb --parallel-load
+```
+
+## Dry run
+
+```bash
+crdb-dump load --db=mydb --data-dir=crdb_dump_output/mydb --dry-run
+```
+
+## Resumable loads
+
+Loads record progress so re-runs skip already-loaded chunks (idempotent):
+
+```bash
+# single shared log file
+crdb-dump load --db=mydb --data-dir=... --resume-log=resume.json
+
+# one log per table
+crdb-dump load --db=mydb --data-dir=... --resume-log-dir=resume/
+
+# abort on the first failed chunk
+crdb-dump load --db=mydb --data-dir=... --resume-log-dir=resume/ --resume-strict
+```
+
+## Selecting tables on load
+
+```bash
+crdb-dump load --db=mydb --data-dir=... --include-tables=mydb.public.users
+crdb-dump load --db=mydb --data-dir=... --exclude-tables=mydb.public.audit_log
+```

--- a/docs/guides/migration-limitations.md
+++ b/docs/guides/migration-limitations.md
@@ -1,0 +1,46 @@
+# Migration & Limitations
+
+## What crdb-dump is
+
+A **logical, point-in-time** dump/restore tool: it exports DDL (`SHOW CREATE`) and
+table data (chunked `SELECT`), and restores via `CREATE` + `COPY`. It is ideal for
+clones, dev/test seeding, selective extracts, and backups of static or quiesced
+data.
+
+## What crdb-dump is not
+
+It is **not** a live-migration tool. It has no change-data-capture, no continuous
+replication, and no cutover orchestration. For minimal-downtime or continuous
+migration, use CockroachDB's purpose-built tooling:
+
+- **MOLT** (Migrate Off Legacy Technology) — Fetch (bulk load), **Replicator**
+  (continuous replication), and Verify. The right choice for minimal-downtime
+  migrations.
+- **Logical Data Replication (LDR)** — continuous, table-level CockroachDB↔CockroachDB
+  replication (self-hosted clusters).
+
+## CockroachDB Cloud tier moves (Basic → Standard → Advanced)
+
+The documented tier-to-tier path is an **export/import via cloud storage**
+workflow. crdb-dump can automate that pattern — **with a write-freeze window** on
+the source (stop writes → dump → restore). For a live/near-zero-downtime tier
+move, use MOLT, and for CockroachDB-to-CockroachDB migrations contact your
+Cockroach Labs account team.
+
+## Consistency caveat
+
+crdb-dump reads each table independently with `OFFSET`/`LIMIT` and **does not use
+`AS OF SYSTEM TIME`**. A dump taken while the database is being written is
+therefore **not** a transactionally consistent snapshot across tables. For a
+consistent dump, quiesce writes for the duration of the export.
+
+!!! note "Planned enhancement"
+    Adding an `AS OF SYSTEM TIME` option (read all tables at a single cluster
+    timestamp) is tracked as future work to make consistent online snapshots
+    possible.
+
+## Further reading
+
+- [CockroachDB MOLT](https://www.cockroachlabs.com/docs/molt/migration-strategy)
+- [Logical Data Replication](https://www.cockroachlabs.com/docs/stable/logical-data-replication-overview)
+- [Migrate from Standard or Basic to Advanced](https://www.cockroachlabs.com/docs/cockroachcloud/migrate-from-standard-to-advanced)

--- a/docs/guides/multi-schema.md
+++ b/docs/guides/multi-schema.md
@@ -1,0 +1,31 @@
+# Multi-Schema (non-`public`) Objects
+
+CockroachDB objects are three-part: `database.schema.table`. crdb-dump is
+schema-aware everywhere — objects in non-`public` schemas are exported and
+restored correctly (filenames, manifests, DDL, and `COPY` targets are all fully
+qualified).
+
+## `--tables` input forms
+
+| Input | Interpreted as |
+| --- | --- |
+| `users` | `<db>.public.users` |
+| `cpkit.tasks` | `<db>.cpkit.tasks` |
+| `mydb.cpkit.tasks` | `mydb.cpkit.tasks` |
+
+A two-part name is `schema.table` (the database comes from `--db`), **not** the
+legacy `database.table`.
+
+## Example
+
+```bash
+# Export a table in the cpkit schema
+crdb-dump export --db=mydb --tables=cpkit.tasks --data --data-format=csv
+```
+
+This produces `mydb.cpkit.tasks_001.csv` and
+`mydb.cpkit.tasks.manifest.json`. A full-database export additionally emits
+`CREATE SCHEMA IF NOT EXISTS "cpkit";` in the schema file so a fresh-database
+restore works.
+
+See the [Naming Model](../reference/naming-model.md) reference for details.

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -1,0 +1,19 @@
+# Permissions
+
+Add `--include-permissions` to export roles, grants, and role memberships
+alongside the schema:
+
+```bash
+crdb-dump export --db=mydb --include-permissions
+```
+
+This writes, under `crdb_dump_output/mydb/`:
+
+- `roles.sql` — `CREATE ROLE` statements
+- `grants.sql` — object `GRANT` statements
+- `role_memberships.sql` — role membership grants (with `WITH ADMIN OPTION` where
+  applicable)
+- `permissions.sql` — an aggregate of all of the above, with an export timestamp
+
+Apply them during restore with `crdb-dump load --schema=...` (or run the SQL
+directly), after the schema objects exist.

--- a/docs/guides/region-aware.md
+++ b/docs/guides/region-aware.md
@@ -1,0 +1,26 @@
+# Region-Aware Export & Import
+
+For multi-region databases, `--region` filters by table locality on export and by
+manifest region on import.
+
+## Export a single region
+
+```bash
+crdb-dump export --db=mydb --data --data-format=csv --region=us-east1
+```
+
+Only tables whose locality matches `us-east1` are exported. Each manifest records
+the table's region.
+
+## Import a single region
+
+```bash
+crdb-dump load --db=mydb --data-dir=crdb_dump_output/mydb --region=us-east1
+```
+
+Chunks whose manifest region does not match are skipped.
+
+!!! note
+    Region metadata comes from `SHOW TABLES` locality. On a single-region (or
+    non-multi-region) cluster there are no regions to filter on, and `--region`
+    selects nothing.

--- a/docs/guides/s3-storage.md
+++ b/docs/guides/s3-storage.md
@@ -1,0 +1,43 @@
+# S3-Compatible Storage
+
+crdb-dump can write data chunks to and read them from any S3-compatible store
+(AWS S3, MinIO, Cohesity) with `--use-s3`.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--use-s3` | Enable S3 upload (export) / download (load) of data chunks |
+| `--s3-bucket` | Bucket name |
+| `--s3-prefix` | Key prefix under which chunks are stored |
+| `--s3-endpoint` | Custom endpoint (e.g. MinIO/Cohesity) |
+| `--s3-access-key` | Access key (or `AWS_ACCESS_KEY_ID`) |
+| `--s3-secret-key` | Secret key (or `AWS_SECRET_ACCESS_KEY`) |
+
+## Export to MinIO
+
+```bash
+crdb-dump export --db=mydb --data --data-format=csv --chunk-size=1000 \
+  --use-s3 \
+  --s3-bucket=crdb-test-bucket \
+  --s3-endpoint=http://localhost:9000 \
+  --s3-access-key=minioadmin \
+  --s3-secret-key=minioadmin \
+  --s3-prefix=backup1/
+```
+
+## Load from MinIO
+
+```bash
+crdb-dump load --db=mydb \
+  --data-dir=crdb_dump_output/mydb \
+  --use-s3 \
+  --s3-bucket=crdb-test-bucket \
+  --s3-endpoint=http://localhost:9000 \
+  --s3-access-key=minioadmin \
+  --s3-secret-key=minioadmin \
+  --s3-prefix=backup1/ \
+  --validate-csv --parallel-load --resume-log-dir=resume/
+```
+
+The schema file is written locally; only data chunks go to S3.

--- a/docs/guides/type-handling.md
+++ b/docs/guides/type-handling.md
@@ -1,0 +1,30 @@
+# Type Handling
+
+crdb-dump preserves CockroachDB data types across export and restore in both SQL
+and CSV formats.
+
+| Type | SQL export | CSV export |
+| --- | --- | --- |
+| `BYTES` | `decode('0102', 'hex')` | bytea hex `\x0102` |
+| `UUID` | string literal | string |
+| `STRING[]` / arrays | `'{a,b}'` array literal | `{a,b}` |
+| `VECTOR(n)` | `'[1.5,2,3]'` string literal | `[1.5,2,3]` (quoted) |
+| enums (`CREATE TYPE`) | via `SHOW CREATE ALL TYPES` | value as string |
+
+## BYTES
+
+BYTES round-trip safely: SQL exports use `decode(..., 'hex')`, and CSV exports use
+the PostgreSQL bytea hex format (`\x...`) so `COPY ... WITH CSV` decodes them back
+to bytes rather than storing the literal characters.
+
+## VECTOR
+
+CockroachDB returns `VECTOR` values as strings like `[1.5,2,3.25]`. crdb-dump
+preserves them verbatim — in CSV the comma-bearing value is quoted, and `COPY`
+restores it unchanged. The `VECTOR(n)` column type itself is emitted by
+`SHOW CREATE`.
+
+## Enums
+
+User-defined enum types are exported via `SHOW CREATE ALL TYPES` and recreated
+before the tables that use them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+# crdb-dump
+
+A feature-rich CLI for exporting and importing CockroachDB schemas and data:
+parallel chunked exports, manifest checksums, `BYTES`/`UUID`/`ARRAY`/`VECTOR`
+types, multi-schema (non-`public`) objects, permissions, resumable imports,
+S3-compatible storage (MinIO, Cohesity), region-aware filtering, and retry logic.
+
+!!! info "What crdb-dump is — and isn't"
+    crdb-dump is a **logical, point-in-time dump/restore** tool. It is **not** a
+    live-migration tool. For minimal-downtime or continuous migration, use
+    CockroachDB **MOLT** or **Logical Data Replication (LDR)**. See
+    [Migration & Limitations](guides/migration-limitations.md).
+
+## Install
+
+```bash
+pip install crdb-dump
+```
+
+Requires Python 3.10+.
+
+## Quick example
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/mydb?sslmode=disable"
+
+# Export full schema + chunked CSV data
+crdb-dump export --db=mydb --data --data-format=csv --chunk-size=1000
+
+# Restore into a fresh database
+crdb-dump load --db=mydb \
+  --schema=crdb_dump_output/mydb/mydb_schema.sql \
+  --data-dir=crdb_dump_output/mydb --validate-csv
+```
+
+See [Getting Started](getting-started/installation.md) to go further.

--- a/docs/recipes/cross-env-copy.md
+++ b/docs/recipes/cross-env-copy.md
@@ -1,0 +1,28 @@
+# Cross-Environment Copy
+
+Copy a database from one cluster to another (e.g. staging → local).
+
+!!! warning "Consistency"
+    crdb-dump takes a logical snapshot without `AS OF SYSTEM TIME`. Quiesce writes
+    on the source for a consistent copy. See
+    [Migration & Limitations](../guides/migration-limitations.md).
+
+## Export from the source
+
+```bash
+export CRDB_URL="cockroachdb://user@source-host:26257/mydb?sslmode=verify-full&..."
+crdb-dump export --db=mydb --data --data-format=csv --chunk-size=1000 \
+  --out-dir=copy_out
+```
+
+## Load into the target
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/mydb?sslmode=disable"
+cockroach sql --insecure -e "CREATE DATABASE IF NOT EXISTS mydb;"
+
+crdb-dump load --db=mydb \
+  --schema=copy_out/mydb/mydb_schema.sql \
+  --data-dir=copy_out/mydb \
+  --validate-csv --parallel-load --resume-log-dir=resume/
+```

--- a/docs/recipes/full-dump-restore.md
+++ b/docs/recipes/full-dump-restore.md
@@ -1,0 +1,34 @@
+# Full Database Dump & Restore
+
+Export an entire database (schema + data), then restore it into a fresh database.
+
+## Export
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/mydb?sslmode=disable"
+crdb-dump export --db=mydb --data --data-format=csv --chunk-size=1000
+```
+
+Produces `crdb_dump_output/mydb/mydb_schema.sql` plus per-table chunk files and
+manifests.
+
+## Restore into a fresh database
+
+```bash
+cockroach sql --insecure -e "DROP DATABASE IF EXISTS mydb CASCADE; CREATE DATABASE mydb;"
+
+crdb-dump load --db=mydb \
+  --schema=crdb_dump_output/mydb/mydb_schema.sql \
+  --data-dir=crdb_dump_output/mydb \
+  --validate-csv --parallel-load --resume-log-dir=resume/
+```
+
+The schema file recreates non-`public` schemas, enum types, sequences, tables,
+and validates foreign keys.
+
+## Verify
+
+```bash
+cockroach sql --insecure -d mydb -e "SELECT count(*) FROM users;"
+crdb-dump export --db=mydb --verify
+```

--- a/docs/recipes/s3-round-trip.md
+++ b/docs/recipes/s3-round-trip.md
@@ -1,0 +1,34 @@
+# S3 Round-Trip (MinIO)
+
+Export data chunks to an S3-compatible store and restore from it.
+
+## Export to MinIO
+
+```bash
+crdb-dump export --db=mydb --data --data-format=csv --chunk-size=1000 \
+  --use-s3 \
+  --s3-bucket=crdb-test-bucket \
+  --s3-endpoint=http://localhost:9000 \
+  --s3-access-key=minioadmin \
+  --s3-secret-key=minioadmin \
+  --s3-prefix=backup1/ \
+  --out-dir=s3_out
+```
+
+## Restore from MinIO
+
+```bash
+cockroach sql --insecure -e "DROP DATABASE IF EXISTS mydb CASCADE; CREATE DATABASE mydb;"
+
+# schema is local; data chunks are pulled from S3
+crdb-dump load --db=mydb \
+  --schema=s3_out/mydb/mydb_schema.sql \
+  --data-dir=s3_out/mydb \
+  --use-s3 \
+  --s3-bucket=crdb-test-bucket \
+  --s3-endpoint=http://localhost:9000 \
+  --s3-access-key=minioadmin \
+  --s3-secret-key=minioadmin \
+  --s3-prefix=backup1/ \
+  --validate-csv --parallel-load --resume-log-dir=resume/
+```

--- a/docs/recipes/selective-tables.md
+++ b/docs/recipes/selective-tables.md
@@ -1,0 +1,26 @@
+# Selective Tables / Schemas
+
+Export and restore a subset of objects.
+
+## Export specific objects
+
+```bash
+# table / schema.table / db.schema.table forms all work
+crdb-dump export --db=mydb \
+  --tables=public.users,cpkit.tasks \
+  --data --data-format=csv
+```
+
+For schema DDL of the selected objects, add `--per-table` to get one file each.
+
+## Restore only some tables
+
+`--data-dir` loads every manifest it finds; restrict with `--include-tables` (or
+exclude with `--exclude-tables`), using fully-qualified names:
+
+```bash
+crdb-dump load --db=mydb \
+  --data-dir=crdb_dump_output/mydb \
+  --include-tables=mydb.cpkit.tasks \
+  --validate-csv --resume-log-dir=resume/
+```

--- a/docs/recipes/verify-resume.md
+++ b/docs/recipes/verify-resume.md
@@ -1,0 +1,27 @@
+# Verify & Resume
+
+## Verify chunk checksums
+
+After an export, validate every chunk against its manifest SHA-256:
+
+```bash
+crdb-dump export --db=mydb --verify
+```
+
+## Resume an interrupted load
+
+Loads record progress per chunk. If a load is interrupted, re-running with the
+same resume log skips chunks that already succeeded:
+
+```bash
+# first attempt (interrupted partway)
+crdb-dump load --db=mydb --data-dir=crdb_dump_output/mydb \
+  --resume-log-dir=resume/ --validate-csv --parallel-load
+
+# re-run — already-loaded chunks are skipped
+crdb-dump load --db=mydb --data-dir=crdb_dump_output/mydb \
+  --resume-log-dir=resume/ --validate-csv --parallel-load --resume-strict
+```
+
+The second run reports `Skipped` for chunks already present, making restarts safe
+and idempotent.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,9 @@
+# CLI Reference
+
+The following is generated from the crdb-dump command-line interface.
+
+::: mkdocs-click
+    :module: crdb_dump.cli
+    :command: main
+    :prog_name: crdb-dump
+    :depth: 1

--- a/docs/reference/manifest-format.md
+++ b/docs/reference/manifest-format.md
@@ -1,0 +1,27 @@
+# Manifest Format
+
+Each exported table gets a `database.schema.table.manifest.json` describing its
+chunks. Example:
+
+```json
+{
+  "table": "mydb.public.users",
+  "region": "N/A",
+  "chunks": [
+    { "file": "mydb.public.users_001.csv", "rows": 1000, "sha256": "<hex>" },
+    { "file": "mydb.public.users_002.csv", "rows": 1000, "sha256": "<hex>" }
+  ]
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `table` | Fully-qualified `database.schema.table` name |
+| `region` | Table locality (or `N/A` on single-region clusters) |
+| `chunks[].file` | Chunk filename (relative to the data directory) |
+| `chunks[].rows` | Row count in the chunk |
+| `chunks[].sha256` | SHA-256 checksum of the chunk file |
+
+The loader reads every `*.manifest.json` in `--data-dir`, loads each chunk via
+`COPY`, and records progress under a resume-log key derived from the manifest's
+`table` value.

--- a/docs/reference/naming-model.md
+++ b/docs/reference/naming-model.md
@@ -1,0 +1,34 @@
+# Naming Model
+
+CockroachDB objects are three-part: `database.schema.table`. crdb-dump uses this
+fully-qualified form consistently across SQL, filenames, manifests, and resume
+logs.
+
+## `--tables` / `--exclude-tables` input
+
+| Input | Interpreted as |
+| --- | --- |
+| `users` | `<db>.public.users` |
+| `cpkit.tasks` | `<db>.cpkit.tasks` |
+| `mydb.cpkit.tasks` | `mydb.cpkit.tasks` |
+
+A two-part name means `schema.table` (database from `--db`), **not** the legacy
+`database.table`. An explicit database prefix must match `--db`.
+
+## Identifier quoting
+
+All identifiers (database, schema, table, column) are double-quoted when used in
+SQL, so mixed-case and reserved-word names work correctly and safely.
+
+## File and manifest naming
+
+Data files and manifests use the `database.schema.table` stem:
+
+```
+mydb.public.users_001.csv
+mydb.public.users.manifest.json
+mydb.cpkit.tasks_001.csv
+mydb.cpkit.tasks.manifest.json
+```
+
+Resume-log keys are derived from the same `database.schema.table` name.

--- a/docs/superpowers/plans/2026-06-26-docs-site.md
+++ b/docs/superpowers/plans/2026-06-26-docs-site.md
@@ -1,0 +1,739 @@
+# crdb-dump Documentation Site Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a MkDocs (Material) documentation site for crdb-dump, mirroring `langchain-cockroachdb`, with an auto-generated CLI reference and auto-deploy to GitHub Pages.
+
+**Architecture:** MkDocs + Material theme at the repo root (`mkdocs.yml` + `docs/`). CLI reference is generated from the Click app via `mkdocs-click`. A GitHub Action deploys to the `gh-pages` branch on push to `main`. Each phase ends with `mkdocs build --strict` passing.
+
+**Tech Stack:** MkDocs, mkdocs-material, mkdocs-click, pymdown-extensions, GitHub Actions.
+
+## Global Constraints
+
+- Tooling: MkDocs + Material; CLI reference via `mkdocs-click` (NOT mkdocstrings).
+- New deps live under `[project.optional-dependencies] docs` only.
+- Every phase must end with `mkdocs build --strict` exiting 0 (no warnings).
+- Deploy: `mkdocs gh-deploy --force` to `gh-pages` from `.github/workflows/docs.yml` on push to `main`.
+- Site URL: `https://viragtripathi.github.io/crdb-dump/`.
+- Commit messages: plain, no AI/bot attribution.
+- Existing unit + integration test suite must remain green (unchanged by docs work).
+- Build/verify in the repo `.venv` (Python 3.12).
+
+---
+
+## Task 1: Scaffold — deps, mkdocs.yml, Home page
+
+**Files:**
+- Modify: `pyproject.toml` (add `docs` extra)
+- Create: `mkdocs.yml`
+- Create: `docs/index.md`
+
+**Interfaces:**
+- Produces: a buildable MkDocs site whose nav references only files that exist in
+  this task; later tasks add the remaining pages and uncomment their nav entries.
+
+- [ ] **Step 1: Add the `docs` extra to `pyproject.toml`**
+
+In `[project.optional-dependencies]`, add alongside `dev`:
+```toml
+docs = [
+    "mkdocs-material>=9.5",
+    "mkdocs-click>=0.8",
+    "pymdown-extensions>=10.7",
+]
+```
+
+- [ ] **Step 2: Install docs deps**
+
+Run:
+```bash
+source .venv/bin/activate
+pip install -e ".[docs]"
+```
+Expected: installs mkdocs-material, mkdocs-click, pymdown-extensions.
+
+- [ ] **Step 3: Create `mkdocs.yml`** (nav lists only Home for now; later tasks extend it)
+
+```yaml
+site_name: crdb-dump
+site_description: Export and import CockroachDB schemas and data — SQL, JSON, YAML, or chunked CSV.
+site_url: https://viragtripathi.github.io/crdb-dump/
+repo_url: https://github.com/viragtripathi/crdb-dump
+repo_name: viragtripathi/crdb-dump
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+
+plugins:
+  - search
+  - mkdocs-click
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+```
+
+- [ ] **Step 4: Create `docs/index.md`**
+
+```markdown
+# crdb-dump
+
+A feature-rich CLI for exporting and importing CockroachDB schemas and data:
+parallel chunked exports, manifest checksums, `BYTES`/`UUID`/`ARRAY`/`VECTOR`
+types, multi-schema (non-`public`) objects, permissions, resumable imports,
+S3-compatible storage (MinIO, Cohesity), region-aware filtering, and retry logic.
+
+!!! info "What crdb-dump is — and isn't"
+    crdb-dump is a **logical, point-in-time dump/restore** tool. It is **not** a
+    live-migration tool. For minimal-downtime or continuous migration, use
+    CockroachDB **MOLT** or **Logical Data Replication (LDR)**. See
+    [Migration & Limitations](guides/migration-limitations.md).
+
+## Install
+
+```bash
+pip install crdb-dump
+```
+
+Requires Python 3.10+.
+
+## Quick example
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/mydb?sslmode=disable"
+
+# Export full schema + chunked CSV data
+crdb-dump export --db=mydb --data --data-format=csv --chunk-size=1000
+
+# Restore into a fresh database
+crdb-dump load --db=mydb \
+  --schema=crdb_dump_output/mydb/mydb_schema.sql \
+  --data-dir=crdb_dump_output/mydb --validate-csv
+```
+
+See [Getting Started](getting-started/installation.md) to go further.
+```
+
+- [ ] **Step 5: Build strict**
+
+Run: `mkdocs build --strict`
+Expected: exits 0, builds `site/`. (The `index.md` links to pages added later;
+`--strict` will warn about those missing links. To avoid that now, the links in
+`index.md` point to files created in Tasks 2 and 3 — so run this step's strict
+build only AFTER Task 3, OR temporarily build non-strict here.) For this task,
+run `mkdocs build` (non-strict) and confirm it succeeds; strict is enforced from
+Task 3 onward once those targets exist.
+
+- [ ] **Step 6: Commit**
+
+```bash
+echo "site/" >> .gitignore
+git add pyproject.toml mkdocs.yml docs/index.md .gitignore
+git commit -m "Scaffold MkDocs Material docs site (deps, config, home page)"
+```
+
+---
+
+## Task 2: Getting Started section
+
+**Files:**
+- Create: `docs/getting-started/installation.md`
+- Create: `docs/getting-started/quickstart.md`
+- Create: `docs/getting-started/configuration.md`
+- Modify: `mkdocs.yml` (add Getting Started nav)
+
+- [ ] **Step 1: Create `docs/getting-started/installation.md`**
+
+Required content:
+```markdown
+# Installation
+
+```bash
+pip install crdb-dump
+```
+
+Requires **Python 3.10+**.
+
+## From source (development)
+
+```bash
+git clone https://github.com/viragtripathi/crdb-dump
+cd crdb-dump
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Verify:
+
+```bash
+crdb-dump version
+```
+```
+
+- [ ] **Step 2: Create `docs/getting-started/quickstart.md`**
+
+Required content (must include export + load commands and mention the output layout):
+```markdown
+# Quick Start
+
+## 1. Point at a cluster
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/mydb?sslmode=disable"
+```
+
+## 2. Export schema + data
+
+```bash
+crdb-dump export --db=mydb --data --data-format=csv --chunk-size=1000
+```
+
+Output lands under `crdb_dump_output/mydb/`:
+
+- `mydb_schema.sql` — full DDL (dependency-ordered)
+- `mydb.<schema>.<table>_NNN.csv` — chunked data
+- `mydb.<schema>.<table>.manifest.json` — checksummed chunk manifest
+
+## 3. Restore
+
+```bash
+crdb-dump load --db=mydb \
+  --schema=crdb_dump_output/mydb/mydb_schema.sql \
+  --data-dir=crdb_dump_output/mydb \
+  --validate-csv
+```
+
+## 4. Verify checksums
+
+```bash
+crdb-dump export --db=mydb --verify
+```
+```
+
+- [ ] **Step 3: Create `docs/getting-started/configuration.md`**
+
+Required content — connection options:
+```markdown
+# Configuration
+
+## Connection
+
+crdb-dump connects via `CRDB_URL` (preferred) or defaults to
+`localhost:26257`:
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/mydb?sslmode=disable"
+# postgresql:// URLs are also accepted and normalized
+export CRDB_URL="postgresql://root@host:26257/mydb?sslmode=disable"
+```
+
+### TLS / secure clusters
+
+Provide a certs directory (used when `CRDB_URL` is not set):
+
+```bash
+crdb-dump export --db=mydb --certs-dir ~/certs
+```
+
+This uses `sslmode=verify-full` with `ca.crt`, `client.root.crt`, `client.root.key`.
+
+Use `--print-connection` to print the resolved URL (credentials redacted).
+
+## S3 / object storage
+
+S3 credentials can come from flags or the standard AWS env vars
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. See
+[S3-Compatible Storage](../guides/s3-storage.md).
+```
+
+- [ ] **Step 4: Extend `mkdocs.yml` nav**
+
+Append under `nav:` after `Home`:
+```yaml
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Quick Start: getting-started/quickstart.md
+      - Configuration: getting-started/configuration.md
+```
+
+- [ ] **Step 5: Build strict**
+
+Run: `mkdocs build --strict`
+Expected: exits 0. (configuration.md links to ../guides/s3-storage.md created in
+Task 3; if strict warns, proceed to Task 3 then re-run. Order Tasks 2→3 without
+committing a strict-failing state: build non-strict here, strict after Task 3.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/getting-started mkdocs.yml
+git commit -m "docs: Getting Started (installation, quickstart, configuration)"
+```
+
+---
+
+## Task 3: Guides section (incl. Migration & Limitations)
+
+**Files:**
+- Create: `docs/guides/export-schema.md`, `export-data.md`, `import-restore.md`,
+  `multi-schema.md`, `type-handling.md`, `permissions.md`, `region-aware.md`,
+  `s3-storage.md`, `migration-limitations.md`
+- Modify: `mkdocs.yml` (add Guides nav)
+
+Each page below lists its required headings and the exact commands/snippets it
+must contain. Prose connecting them should be one to three sentences per section.
+
+- [ ] **Step 1: `docs/guides/export-schema.md`**
+
+Sections + must-include:
+- "# Exporting Schema"
+- Full-DB behavior: explain `crdb-dump export --db=mydb` writes `mydb_schema.sql`
+  via native `SHOW CREATE ALL TYPES` + `SHOW CREATE ALL TABLES` (dependency-ordered,
+  FK constraints validated post-load), and emits `CREATE SCHEMA IF NOT EXISTS` for
+  non-`public` schemas.
+- Formats: `--format sql|json|yaml`.
+- Per-object files: `--per-table` (e.g. `table_mydb.public.users.sql`).
+- Selective: `--tables`, `--exclude-tables`.
+- Permissions: `--include-permissions` (link to permissions.md).
+
+- [ ] **Step 2: `docs/guides/export-data.md`**
+
+Must include commands for: `--data --data-format=csv|sql`, `--chunk-size`,
+`--data-compress` (gzip), `--data-order` / `--data-order-desc` / `--data-order-strict`,
+`--data-parallel`, `--data-limit`. Explain manifest + sha256 per chunk.
+
+- [ ] **Step 3: `docs/guides/import-restore.md`**
+
+Must include: `crdb-dump load` with `--schema`, `--data-dir`, `--validate-csv`,
+`--parallel-load`, `--dry-run`, and resume via `--resume-log` / `--resume-log-dir`
+/ `--resume-strict`. Note loads use `COPY` and are idempotent with resume logs.
+
+- [ ] **Step 4: `docs/guides/multi-schema.md`**
+
+Must include: three-part `database.schema.table` model; that non-`public` schemas
+are fully supported; `--tables` accepts `table` (→ public), `schema.table`, or
+`db.schema.table`; example exporting `cpkit.tasks`. Link to
+[Naming Model](../reference/naming-model.md).
+
+- [ ] **Step 5: `docs/guides/type-handling.md`**
+
+Must include: BYTES (`decode('..','hex')` in SQL, `\x..` bytea in CSV), UUID,
+`STRING[]`/arrays, `VECTOR` (round-trips as `[..]` strings in SQL and CSV),
+enums (exported via `SHOW CREATE ALL TYPES`).
+
+- [ ] **Step 6: `docs/guides/permissions.md`**
+
+Must include: `--include-permissions` exports roles, grants, role memberships to
+`permissions.sql` (+ `roles.sql`, `grants.sql`, `role_memberships.sql`).
+
+- [ ] **Step 7: `docs/guides/region-aware.md`**
+
+Must include: `--region` filters tables by locality on export and chunks by
+manifest region on load; example with a multi-region database.
+
+- [ ] **Step 8: `docs/guides/s3-storage.md`**
+
+Must include: `--use-s3`, `--s3-bucket`, `--s3-prefix`, `--s3-endpoint`
+(MinIO/Cohesity), `--s3-access-key` / `--s3-secret-key` (or AWS env vars); a full
+export-to-S3 and load-from-S3 example.
+
+- [ ] **Step 9: `docs/guides/migration-limitations.md`**
+
+Must include exactly these points:
+- crdb-dump is a point-in-time **logical** dump/restore tool, **not** live migration.
+- For minimal-downtime/continuous migration use **MOLT** (Fetch + Replicator +
+  Verify) or **LDR** (self-hosted CRDB↔CRDB).
+- Cloud tier moves (Basic→Standard→Advanced) follow the documented
+  export/import-via-storage path; crdb-dump can automate it **with a write-freeze**.
+- Consistency caveat: tables are read independently **without `AS OF SYSTEM TIME`**,
+  so a dump of a live database is not transactionally consistent across tables;
+  quiesce writes for a consistent snapshot. (AOST is a planned enhancement.)
+- Links: CockroachDB MOLT and LDR docs.
+
+- [ ] **Step 10: Extend `mkdocs.yml` nav**
+
+```yaml
+  - Guides:
+      - Export Schema: guides/export-schema.md
+      - Export Data: guides/export-data.md
+      - Import & Restore: guides/import-restore.md
+      - Multi-Schema Objects: guides/multi-schema.md
+      - Type Handling: guides/type-handling.md
+      - Permissions: guides/permissions.md
+      - Region-Aware: guides/region-aware.md
+      - S3-Compatible Storage: guides/s3-storage.md
+      - Migration & Limitations: guides/migration-limitations.md
+```
+
+- [ ] **Step 11: Build strict**
+
+Run: `mkdocs build --strict`
+Expected: exits 0 with no warnings (all index/config cross-links now resolve).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add docs/guides mkdocs.yml
+git commit -m "docs: Guides section incl. Migration & Limitations"
+```
+
+---
+
+## Task 4: Recipes section
+
+**Files:**
+- Create: `docs/recipes/full-dump-restore.md`, `selective-tables.md`,
+  `cross-env-copy.md`, `s3-round-trip.md`, `verify-resume.md`
+- Modify: `mkdocs.yml`
+
+- [ ] **Step 1: Create the five recipe pages**
+
+Each is a short task-oriented page with copy-paste commands:
+- `full-dump-restore.md` — export full DB (schema+CSV), drop/recreate, load schema
+  + data-dir, verify counts.
+- `selective-tables.md` — `--tables=schema.table,...` export and matching load with
+  `--include-tables`.
+- `cross-env-copy.md` — export from source `CRDB_URL`, then load against a
+  different target `CRDB_URL` (note: quiesce writes for consistency).
+- `s3-round-trip.md` — export `--use-s3` to MinIO, load `--use-s3` from MinIO with
+  `--resume-log-dir`.
+- `verify-resume.md` — `--verify` checksums; simulate a partial load and re-run to
+  show skipped chunks via `--resume-log-dir`.
+
+- [ ] **Step 2: Extend `mkdocs.yml` nav**
+
+```yaml
+  - Recipes:
+      - Full Dump & Restore: recipes/full-dump-restore.md
+      - Selective Tables: recipes/selective-tables.md
+      - Cross-Environment Copy: recipes/cross-env-copy.md
+      - S3 Round-Trip: recipes/s3-round-trip.md
+      - Verify & Resume: recipes/verify-resume.md
+```
+
+- [ ] **Step 3: Build strict**
+
+Run: `mkdocs build --strict`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/recipes mkdocs.yml
+git commit -m "docs: Recipes (full restore, selective, cross-env, S3, verify/resume)"
+```
+
+---
+
+## Task 5: CLI Reference (mkdocs-click) + naming/manifest pages
+
+**Files:**
+- Create: `docs/reference/cli.md`, `naming-model.md`, `manifest-format.md`
+- Modify: `mkdocs.yml`
+
+- [ ] **Step 1: Create `docs/reference/cli.md`**
+
+```markdown
+# CLI Reference
+
+The following is generated from the crdb-dump command-line interface.
+
+::: mkdocs-click
+    :module: crdb_dump.cli
+    :command: main
+    :prog_name: crdb-dump
+    :depth: 1
+```
+
+- [ ] **Step 2: Create `docs/reference/naming-model.md`**
+
+Must include: objects are three-part `database.schema.table`; `--tables` input
+forms (`table` → public, `schema.table`, `db.schema.table`); identifiers are
+quoted automatically; file/manifest stems use `db.schema.table`.
+
+- [ ] **Step 3: Create `docs/reference/manifest-format.md`**
+
+Must include a sample manifest JSON and field descriptions:
+```json
+{
+  "table": "mydb.public.users",
+  "region": "N/A",
+  "chunks": [
+    { "file": "mydb.public.users_001.csv", "rows": 1000, "sha256": "<hex>" }
+  ]
+}
+```
+Explain resume-log keys derive from `db.schema.table`.
+
+- [ ] **Step 4: Extend `mkdocs.yml` nav**
+
+```yaml
+  - CLI Reference:
+      - Commands: reference/cli.md
+      - Naming Model: reference/naming-model.md
+      - Manifest Format: reference/manifest-format.md
+```
+
+- [ ] **Step 5: Build strict and confirm CLI renders**
+
+Run: `mkdocs build --strict`
+Expected: exits 0. Then:
+```bash
+grep -rq "crdb-dump export" site/reference/cli/index.html && echo "CLI reference rendered"
+```
+Expected: prints "CLI reference rendered" (mkdocs-click expanded the Click app).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/reference mkdocs.yml
+git commit -m "docs: CLI reference (mkdocs-click) + naming model + manifest format"
+```
+
+---
+
+## Task 6: About + Development sections
+
+**Files:**
+- Create: `docs/about/changelog.md`, `docs/about/license.md`
+- Create: `docs/development/contributing.md`, `testing.md`, `releasing.md`
+- Modify: `mkdocs.yml`
+
+- [ ] **Step 1: Create `docs/about/changelog.md`** (include the root CHANGELOG)
+
+```markdown
+# Changelog
+
+--8<-- "CHANGELOG.md"
+```
+(The `pymdownx.snippets` extension resolves `--8<--`. Ensure snippets base path
+includes the repo root — it does by default when building from repo root.)
+
+- [ ] **Step 2: Create `docs/about/license.md`**
+
+```markdown
+# License
+
+crdb-dump is released under the MIT License.
+
+--8<-- "LICENSE"
+```
+
+- [ ] **Step 3: Create `docs/development/contributing.md`**
+
+Must include: clone + `pip install -e ".[dev]"`, run `pytest -m "not integration"`,
+link to Testing and Releasing; PRs welcome.
+
+- [ ] **Step 4: Create `docs/development/testing.md`**
+
+Must include the three levels:
+```bash
+pytest -m "not integration"
+export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+pytest -m integration
+./test-local.sh
+```
+
+- [ ] **Step 5: Create `docs/development/releasing.md`**
+
+Must include: bump `pyproject.toml` version + CHANGELOG, run the **Release**
+GitHub Action with the matching version; PyPI Trusted Publishing (OIDC); one-time
+Trusted Publisher setup.
+
+- [ ] **Step 6: Extend `mkdocs.yml` nav**
+
+```yaml
+  - Development:
+      - Contributing: development/contributing.md
+      - Testing: development/testing.md
+      - Releasing: development/releasing.md
+  - About:
+      - Changelog: about/changelog.md
+      - License: about/license.md
+```
+
+- [ ] **Step 7: Build strict**
+
+Run: `mkdocs build --strict`
+Expected: exits 0 (snippets for CHANGELOG.md and LICENSE resolve).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/about docs/development mkdocs.yml
+git commit -m "docs: About (changelog, license) + Development (contributing, testing, releasing)"
+```
+
+---
+
+## Task 7: Deploy workflow + README link
+
+**Files:**
+- Create: `.github/workflows/docs.yml`
+- Modify: `README.md` (add docs link + badge)
+
+- [ ] **Step 1: Create `.github/workflows/docs.yml`**
+
+```yaml
+name: Docs
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "crdb_dump/**"
+      - "CHANGELOG.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+      - name: Build (strict) and deploy
+        run: |
+          mkdocs build --strict
+          mkdocs gh-deploy --force
+```
+
+- [ ] **Step 2: Add docs link + badge to `README.md`**
+
+Add a docs badge to the badge block:
+```markdown
+[![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue.svg)](https://viragtripathi.github.io/crdb-dump/)
+```
+And under the intro paragraph add:
+```markdown
+📖 **Documentation:** https://viragtripathi.github.io/crdb-dump/
+```
+
+- [ ] **Step 3: Validate workflow YAML**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/docs.yml')); print('docs.yml OK')"
+```
+Expected: prints `docs.yml OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/docs.yml README.md
+git commit -m "docs: GitHub Pages deploy workflow + README docs link/badge"
+```
+
+---
+
+## Task 8: Final verification + PR
+
+- [ ] **Step 1: Strict build from clean**
+
+Run:
+```bash
+rm -rf site
+mkdocs build --strict
+```
+Expected: exits 0, no warnings.
+
+- [ ] **Step 2: Confirm test suite still green**
+
+Run:
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+pytest -q
+```
+Expected: all pass (docs work changed no Python).
+
+- [ ] **Step 3: Local preview sanity (optional)**
+
+Run: `mkdocs serve` and open http://127.0.0.1:8000 to spot-check nav and the CLI
+reference page. Stop with Ctrl-C.
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+git push -u origin docs-site
+gh pr create --base main --head docs-site \
+  --title "Add MkDocs documentation site (GitHub Pages)" \
+  --body "MkDocs Material docs site mirroring langchain-cockroachdb: Getting Started, Guides (incl. Migration & Limitations), Recipes, auto-generated CLI Reference (mkdocs-click), Development, About. Deploys to gh-pages on push to main. One-time: set Pages source to gh-pages."
+```
+
+- [ ] **Step 5: Note the one-time Pages setting**
+
+After merge: repo Settings → Pages → Source = `gh-pages` branch. The first
+`main` push then publishes to https://viragtripathi.github.io/crdb-dump/.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** tooling/extra (T1), Getting Started (T2), Guides incl.
+  Migration & Limitations (T3), Recipes (T4), CLI reference + naming + manifest
+  (T5), About + Development incl. Releasing (T6), deploy workflow + README (T7),
+  final verification + PR (T8). All spec sections covered.
+- **Placeholder scan:** config/workflow/snippet content is literal; content pages
+  specify exact required headings and the exact commands/flags to include (these
+  are the actionable spec, not placeholders).
+- **Consistency:** nav paths match created file paths; mkdocs-click directive
+  targets `crdb_dump.cli:main`; site URL and gh-pages deploy consistent across T1/T7/T8.
+- **Build ordering caveat:** `index.md`/`configuration.md` link forward to pages
+  created in T3; run non-strict builds in T1–T2 and enforce `--strict` from T3
+  onward (called out in those tasks).
+```

--- a/docs/superpowers/specs/2026-06-26-docs-site-design.md
+++ b/docs/superpowers/specs/2026-06-26-docs-site-design.md
@@ -1,0 +1,148 @@
+# crdb-dump Documentation Site (Design)
+
+Date: 2026-06-26
+Status: Approved-pending-review
+
+## Problem
+
+`crdb-dump` has a large CLI surface (export/load/version with many options:
+formats, chunking, gzip, ordering, parallelism, resume, validation, S3, region,
+permissions, three-part naming, type handling). The README is straining to hold
+all of it. The project should have a proper documentation website, consistent
+with the CockroachDB ecosystem (e.g. `cockroachdb/langchain-cockroachdb`), and a
+permanent home for guidance that currently only lives in conversation (notably:
+this is a snapshot logical dump/restore tool, not a live-migration tool).
+
+## Goals
+
+1. A MkDocs (Material) documentation site mirroring the `langchain-cockroachdb` setup.
+2. Auto-generated CLI reference that stays in sync with the Click app.
+3. Auto-deploy to GitHub Pages on push to `main`.
+4. A permanent "Migration & Limitations" page capturing what the tool is / isn't.
+
+## Decisions (from brainstorming)
+
+- **Tooling:** MkDocs + Material theme; mirror langchain's theme/extensions.
+- **CLI reference:** auto-generated from the Click app via `mkdocs-click`
+  (no `mkdocstrings` — crdb-dump is a CLI, not an importable library API).
+- **Deploy:** GitHub Action on push to `main` → `mkdocs gh-deploy --force` to the
+  `gh-pages` branch → https://viragtripathi.github.io/crdb-dump/.
+- **Examples:** task-oriented recipe pages with copy-paste shell snippets (no
+  separate runnable `examples/` folder).
+
+## Tooling detail
+
+- `mkdocs.yml` at repo root.
+- Theme `material`: light (`default`) + dark (`slate`) palettes, indigo primary/accent;
+  features `navigation.tabs`, `navigation.sections`, `navigation.expand`,
+  `navigation.top`, `search.suggest`, `search.highlight`, `content.code.copy`,
+  `content.code.annotate`.
+- Plugins: `search`, `mkdocs-click`.
+- Markdown extensions: `pymdownx.highlight` (anchor line numbers),
+  `pymdownx.inlinehilite`, `pymdownx.snippets`, `pymdownx.superfences`,
+  `pymdownx.tabbed` (alternate_style), `pymdownx.details`, `pymdownx.emoji`,
+  `admonition`, `attr_list`, `md_in_html`, `toc` (permalinks).
+- New `[project.optional-dependencies] docs` extra in `pyproject.toml`:
+  `mkdocs-material`, `mkdocs-click`, `pymdown-extensions`.
+
+## Site structure (`docs/`) and nav
+
+```
+Home                      docs/index.md
+Getting Started
+  Installation            docs/getting-started/installation.md
+  Quick Start             docs/getting-started/quickstart.md
+  Configuration           docs/getting-started/configuration.md
+Guides
+  Export Schema           docs/guides/export-schema.md
+  Export Data             docs/guides/export-data.md
+  Import & Restore        docs/guides/import-restore.md
+  Multi-Schema Objects    docs/guides/multi-schema.md
+  Type Handling           docs/guides/type-handling.md
+  Permissions             docs/guides/permissions.md
+  Region-Aware            docs/guides/region-aware.md
+  S3-Compatible Storage   docs/guides/s3-storage.md
+  Migration & Limitations docs/guides/migration-limitations.md
+Recipes
+  Full Dump & Restore     docs/recipes/full-dump-restore.md
+  Selective Tables        docs/recipes/selective-tables.md
+  Cross-Environment Copy  docs/recipes/cross-env-copy.md
+  S3 Round-Trip           docs/recipes/s3-round-trip.md
+  Verify & Resume         docs/recipes/verify-resume.md
+CLI Reference
+  Commands (auto)         docs/reference/cli.md         (mkdocs-click)
+  Naming Model            docs/reference/naming-model.md
+  Manifest Format         docs/reference/manifest-format.md
+About
+  Changelog               docs/about/changelog.md       (includes ../../CHANGELOG.md)
+  License                 docs/about/license.md
+Development
+  Contributing            docs/development/contributing.md
+  Testing                 docs/development/testing.md
+  Releasing               docs/development/releasing.md
+```
+
+### CLI reference page
+
+`docs/reference/cli.md` uses the mkdocs-click directive against the Click group:
+
+```
+::: mkdocs-click
+    :module: crdb_dump.cli
+    :command: main
+```
+
+This renders `export`, `load`, and `version` with all options from the live code.
+
+### Migration & Limitations page
+
+States plainly: crdb-dump is a point-in-time **logical** dump/restore tool. It is
+**not** a live-migration tool — for minimal-downtime/continuous migration use
+CockroachDB **MOLT** (Fetch + Replicator + Verify) or **LDR** (self-hosted
+CRDB↔CRDB). Cloud tier moves (Basic→Standard→Advanced) follow the documented
+export/import-via-storage path, which crdb-dump can automate **with a write-freeze
+window**. Documents the consistency caveat: tables are read independently without
+`AS OF SYSTEM TIME`, so a dump of a live database is not a transactionally
+consistent snapshot across tables; links the AOST enhancement as future work.
+Links to upstream CockroachDB migration docs.
+
+## Hosting / CI
+
+- `.github/workflows/docs.yml`:
+  - Trigger: `push` to `main` on paths `docs/**`, `mkdocs.yml`, `crdb_dump/**`
+    (CLI ref depends on source), plus `workflow_dispatch`.
+  - Steps: checkout; setup Python 3.12; `pip install -e ".[docs]"`;
+    `mkdocs gh-deploy --force` (publishes to the `gh-pages` branch).
+  - Permissions: `contents: write` (to push `gh-pages`).
+- One-time manual step: repo Settings → Pages → source = `gh-pages` branch.
+- README: add a docs-site link and a docs badge.
+
+## Verification
+
+Docs-only change; the gate is:
+- `mkdocs build --strict` passes locally (fails on broken internal links / nav
+  references / missing files) — run before any push.
+- `docs.yml` and existing workflow YAML parse.
+- Existing unit + integration test suite stays green (unchanged).
+
+No database or e2e run is required for the docs themselves.
+
+## Implementation phases
+
+1. `pyproject.toml` `docs` extra + `mkdocs.yml` skeleton (theme/plugins/nav) +
+   `docs/index.md`; `mkdocs build --strict` green with placeholder-free Home.
+2. Getting Started pages.
+3. Guides pages (incl. Migration & Limitations).
+4. Recipes pages.
+5. CLI Reference (mkdocs-click) + Naming Model + Manifest Format.
+6. About (Changelog/License) + Development (Contributing/Testing/Releasing).
+7. `docs.yml` deploy workflow; README docs link/badge.
+8. Final `mkdocs build --strict` + full test suite green; open PR.
+
+Each phase ends with `mkdocs build --strict` passing.
+
+## Out of scope
+
+- Versioned docs (`mike`), internationalization, custom domain.
+- Moving the repo to the `cockroachdb` org (URL would change to
+  `cockroachdb.github.io/crdb-dump`); revisit if/when that happens.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,3 +62,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Quick Start: getting-started/quickstart.md
+      - Configuration: getting-started/configuration.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,59 @@
+site_name: crdb-dump
+site_description: Export and import CockroachDB schemas and data — SQL, JSON, YAML, or chunked CSV.
+site_url: https://viragtripathi.github.io/crdb-dump/
+repo_url: https://github.com/viragtripathi/crdb-dump
+repo_name: viragtripathi/crdb-dump
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+
+plugins:
+  - search
+  - mkdocs-click
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path: ["."]
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,3 +82,7 @@ nav:
       - Cross-Environment Copy: recipes/cross-env-copy.md
       - S3 Round-Trip: recipes/s3-round-trip.md
       - Verify & Resume: recipes/verify-resume.md
+  - CLI Reference:
+      - Commands: reference/cli.md
+      - Naming Model: reference/naming-model.md
+      - Manifest Format: reference/manifest-format.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,3 +76,9 @@ nav:
       - Region-Aware: guides/region-aware.md
       - S3-Compatible Storage: guides/s3-storage.md
       - Migration & Limitations: guides/migration-limitations.md
+  - Recipes:
+      - Full Dump & Restore: recipes/full-dump-restore.md
+      - Selective Tables: recipes/selective-tables.md
+      - Cross-Environment Copy: recipes/cross-env-copy.md
+      - S3 Round-Trip: recipes/s3-round-trip.md
+      - Verify & Resume: recipes/verify-resume.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,3 +66,13 @@ nav:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
       - Configuration: getting-started/configuration.md
+  - Guides:
+      - Export Schema: guides/export-schema.md
+      - Export Data: guides/export-data.md
+      - Import & Restore: guides/import-restore.md
+      - Multi-Schema Objects: guides/multi-schema.md
+      - Type Handling: guides/type-handling.md
+      - Permissions: guides/permissions.md
+      - Region-Aware: guides/region-aware.md
+      - S3-Compatible Storage: guides/s3-storage.md
+      - Migration & Limitations: guides/migration-limitations.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,3 +86,10 @@ nav:
       - Commands: reference/cli.md
       - Naming Model: reference/naming-model.md
       - Manifest Format: reference/manifest-format.md
+  - Development:
+      - Contributing: development/contributing.md
+      - Testing: development/testing.md
+      - Releasing: development/releasing.md
+  - About:
+      - Changelog: about/changelog.md
+      - License: about/license.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,14 +32,19 @@ theme:
     - content.code.copy
     - content.code.annotate
 
+# Brainstorming/planning docs live under docs/superpowers/ but are not part of
+# the published site.
+exclude_docs: |
+  superpowers/
+
 plugins:
   - search
-  - mkdocs-click
 
 markdown_extensions:
   - admonition
   - attr_list
   - md_in_html
+  - mkdocs-click
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ dependencies = [
 dev = [
     "pytest>=8.0"
 ]
+docs = [
+    "mkdocs-material>=9.5",
+    "mkdocs-click>=0.8",
+    "pymdown-extensions>=10.7",
+]
 
 [project.scripts]
 crdb-dump = "crdb_dump.cli:main"


### PR DESCRIPTION
## Summary

A MkDocs (Material) documentation site mirroring `langchain-cockroachdb`, plus a deploy workflow.

- **Tooling:** MkDocs + Material (indigo light/dark, tabs/sections/search/code-copy). CLI reference auto-generated from the Click app via **mkdocs-click** (markdown extension). `[project.optional-dependencies] docs` extra.
- **Sections (25 pages):** Home · Getting Started (install/quickstart/configuration) · Guides (export schema/data, import & restore, multi-schema, type handling incl. VECTOR/BYTES, permissions, region-aware, S3, **Migration & Limitations**) · Recipes (full restore, selective, cross-env, S3 round-trip, verify & resume) · CLI Reference (auto + naming model + manifest format) · Development (contributing/testing/releasing) · About (changelog/license).
- **Migration & Limitations page** captures the live-migration guidance (logical snapshot vs MOLT/LDR, tier moves with write-freeze, the `AS OF SYSTEM TIME` consistency caveat).
- **Deploy:** `.github/workflows/docs.yml` builds `--strict` and runs `mkdocs gh-deploy --force` to `gh-pages` on push to `main`.
- **CHANGELOG:** dated `0.4.0 — 2026-06-26` (was stuck on "unreleased") + a fresh `Unreleased` section; release process documents this step.
- README gets a docs badge + link.
- `docs/superpowers/` (specs/plans) is excluded from the published site.

## One-time after merge

Repo Settings → Pages → Source = `gh-pages` branch. The first `main` push then publishes to https://viragtripathi.github.io/crdb-dump/.

## Verification

- `mkdocs build --strict` is clean (0 warnings); all 25 nav pages build; CLI reference renders from `crdb_dump.cli:main`; CHANGELOG/LICENSE pulled in via snippets.
- `docs.yml` YAML parses.
- Full unit + integration test suite still green (no Python changed).