### PR TITLE
Add --as-of-system-time for consistent point-in-time exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-_No changes yet._
+### Added
+- `--as-of-system-time` on `export`: read all table data at one pinned cluster
+  timestamp for a consistent point-in-time snapshot. The bare flag pins
+  `cluster_logical_timestamp()`; an explicit value (interval, timestamp, or
+  decimal) is used verbatim. The pinned timestamp is recorded in each manifest as
+  `as_of_system_time`.
 
 ## 0.4.0 — 2026-06-26
 

--- a/crdb_dump/cli.py
+++ b/crdb_dump/cli.py
@@ -49,6 +49,10 @@ def main(ctx, verbose):
 @click.option('--data-parallel', is_flag=True, help='Parallel data export')
 @click.option('--data-order-strict', is_flag=True, help='Fail if ordered column(s) not found')
 @click.option('--chunk-size', type=int, default=None, help='Rows per CSV chunk')
+@click.option('--as-of-system-time', 'aost', is_flag=False, flag_value='auto', default=None,
+              help="Read data at a consistent snapshot. The bare flag pins one "
+                   "cluster_logical_timestamp(); or pass a value like '-30s', a "
+                   "timestamp, or a decimal.")
 @click.option('--verify', is_flag=True, help='Verify exported chunk checksums')
 @click.option('--verify-strict', is_flag=True, help='Stop if any checksum fails')
 @click.option('--out-dir', default='crdb_dump_output', help='Output directory for all exports')

--- a/crdb_dump/export/data.py
+++ b/crdb_dump/export/data.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from sqlalchemy import text
 from crdb_dump.export.schema import collect_objects
 from crdb_dump.utils.db_connection import get_sqlalchemy_engine
-from crdb_dump.utils.common import to_sql_literal, to_csv_literal
+from crdb_dump.utils.common import to_sql_literal, to_csv_literal, aost_clause
 from crdb_dump.utils.identifiers import parse_object_name, quote_ident
 from crdb_dump.utils.io import validate_fq_table_names
 
@@ -19,10 +19,17 @@ def export_table_data(engine, table, out_dir, export_format, split, limit, compr
     try:
         obj = parse_object_name(table, default_db=table.split('.')[0])
         base_name = obj.file_base()
+        clause = aost_clause(opts.get("aost_resolved"))
         with retry(retries=retry_count, delay=retry_delay)(engine.connect)() as conn:
+            if clause:
+                # Each AOST read runs in its own transaction at the SAME pinned
+                # timestamp. CockroachDB allows only one AOST per transaction, so
+                # AUTOCOMMIT avoids "inconsistent AS OF SYSTEM TIME" across the
+                # column and chunk queries while still giving a consistent snapshot.
+                conn = conn.execution_options(isolation_level="AUTOCOMMIT")
             cols_res = conn.execute(text(
-                "SELECT column_name FROM information_schema.columns "
-                "WHERE table_name = :t AND table_schema = :s ORDER BY ordinal_position"
+                "SELECT column_name FROM information_schema.columns" + clause +
+                " WHERE table_name = :t AND table_schema = :s ORDER BY ordinal_position"
             ), {"t": obj.table, "s": obj.schema})
             columns = [row[0] for row in cols_res]
             if order:
@@ -55,7 +62,7 @@ def export_table_data(engine, table, out_dir, export_format, split, limit, compr
                 return h.hexdigest()
 
             while True:
-                query = f"SELECT * FROM {obj.fq_quoted()} {order_clause} OFFSET {offset} LIMIT {batch_size}"
+                query = f"SELECT * FROM {obj.fq_quoted()}{clause} {order_clause} OFFSET {offset} LIMIT {batch_size}"
                 if limit and offset >= limit:
                     break
                 rows = conn.execute(text(query)).fetchall()
@@ -114,6 +121,7 @@ def export_table_data(engine, table, out_dir, export_format, split, limit, compr
             with open(manifest_path, 'w') as mf:
                 json.dump({
                     "table": obj.fq_plain(),
+                    "as_of_system_time": opts.get("aost_resolved"),
                     "region": region,
                     "chunks": manifest
                 }, mf, indent=2)
@@ -136,6 +144,15 @@ def export_data(opts, out_dir, logger):
 
     region_filter = opts.get("region")
     locality_map = get_table_locality(engine, opts["db"], logger)
+
+    # Pin the AS OF SYSTEM TIME value ONCE so every table and chunk reads the same
+    # consistent snapshot. "auto" captures a single cluster_logical_timestamp().
+    aost = opts.get("aost")
+    if aost == "auto":
+        with engine.connect() as conn:
+            aost = str(conn.execute(text("SELECT cluster_logical_timestamp()")).scalar())
+        logger.info(f"🕒 Pinned AS OF SYSTEM TIME {aost}")
+    opts["aost_resolved"] = aost
 
     if opts.get("print_connection"):
         print("🔗 Using CockroachDB URL:")

--- a/crdb_dump/utils/common.py
+++ b/crdb_dump/utils/common.py
@@ -27,6 +27,18 @@ def retry(retries=3, delay=1.0, backoff=2.0, exceptions=RETRYABLE_EXCEPTIONS):
         return wrapper
     return decorator_retry
 
+def aost_clause(resolved_value):
+    """Return an ' AS OF SYSTEM TIME ...' SQL fragment, or '' when no AOST.
+
+    The value is single-quoted, which CockroachDB accepts for decimals,
+    intervals (e.g. ``-30s``), and timestamps.
+    """
+    if not resolved_value:
+        return ""
+    escaped = str(resolved_value).replace("'", "''")
+    return f" AS OF SYSTEM TIME '{escaped}'"
+
+
 def to_sql_literal(val):
     if val is None:
         return 'NULL'

--- a/docs/guides/export-data.md
+++ b/docs/guides/export-data.md
@@ -44,6 +44,27 @@ crdb-dump export --db=mydb --data --data-parallel      # export tables concurren
 crdb-dump export --db=mydb --data --data-limit=100000  # cap rows per table
 ```
 
+## Consistent snapshots (`--as-of-system-time`)
+
+By default each table is read independently, so a dump of a live database is not
+consistent across tables. Use `--as-of-system-time` to read every table (and every
+chunk) at one pinned cluster timestamp:
+
+```bash
+# pin one cluster_logical_timestamp() for the whole export
+crdb-dump export --db=mydb --data --as-of-system-time
+
+# or pass an explicit interval / timestamp / decimal
+crdb-dump export --db=mydb --data --as-of-system-time='-30s'
+```
+
+The pinned timestamp is recorded in each manifest as `as_of_system_time`.
+
+!!! warning
+    The timestamp must be within the table's garbage-collection window
+    (`gc.ttlseconds`, default 25h). A very long export against an old timestamp
+    can fail once the snapshot ages out of GC.
+
 ## Verifying
 
 Re-run with `--verify` to validate each chunk against its manifest checksum:

--- a/docs/guides/migration-limitations.md
+++ b/docs/guides/migration-limitations.md
@@ -29,15 +29,20 @@ Cockroach Labs account team.
 
 ## Consistency caveat
 
-crdb-dump reads each table independently with `OFFSET`/`LIMIT` and **does not use
-`AS OF SYSTEM TIME`**. A dump taken while the database is being written is
-therefore **not** a transactionally consistent snapshot across tables. For a
-consistent dump, quiesce writes for the duration of the export.
+By default crdb-dump reads each table independently with `OFFSET`/`LIMIT`, so a
+dump taken while the database is being written is **not** a transactionally
+consistent snapshot across tables.
 
-!!! note "Planned enhancement"
-    Adding an `AS OF SYSTEM TIME` option (read all tables at a single cluster
-    timestamp) is tracked as future work to make consistent online snapshots
-    possible.
+!!! tip "Use `--as-of-system-time` for a consistent snapshot"
+    Pass [`--as-of-system-time`](export-data.md#consistent-snapshots-as-of-system-time)
+    to read every table at one pinned cluster timestamp:
+
+    ```bash
+    crdb-dump export --db=mydb --data --as-of-system-time
+    ```
+
+    The timestamp must stay within the garbage-collection window
+    (`gc.ttlseconds`), so keep exports shorter than that window or raise the TTL.
 
 ## Further reading
 

--- a/docs/superpowers/plans/2026-06-26-as-of-system-time.md
+++ b/docs/superpowers/plans/2026-06-26-as-of-system-time.md
@@ -1,0 +1,339 @@
+# `--as-of-system-time` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Steps use checkbox (`- [ ]`).
+
+**Goal:** Add `--as-of-system-time` to `crdb-dump export` for consistent, pinned point-in-time data dumps.
+
+**Architecture:** A pure `aost_clause()` formatter; resolve/pin the timestamp once in `export_data`; apply the clause to the row and column-discovery queries in `export_table_data`; record it in the manifest.
+
+**Tech Stack:** Python, Click, SQLAlchemy, pytest, CockroachDB.
+
+## Global Constraints
+
+- Flag: `--as-of-system-time` (Click `flag_value='auto'`, `default=None`). Bare → pin one `cluster_logical_timestamp()`; value → verbatim; omitted → off.
+- Pin once; reuse for every table and chunk.
+- Apply to row `SELECT` and column-discovery query; NOT schema DDL.
+- Record pinned timestamp in each manifest as `as_of_system_time` (null when off).
+- Tests: unit + integration + e2e green before push. Plain commit messages.
+- Build/verify in repo `.venv`; live CRDB at `localhost:26257`.
+
+---
+
+## Task 1: `aost_clause()` formatter
+
+**Files:** Modify `crdb_dump/utils/common.py`; Test `tests/test_aost.py`
+
+- [ ] **Step 1: Failing test**
+
+```python
+# tests/test_aost.py
+from crdb_dump.utils.common import aost_clause
+
+def test_none_returns_empty():
+    assert aost_clause(None) == ""
+
+def test_empty_returns_empty():
+    assert aost_clause("") == ""
+
+def test_decimal_value():
+    assert aost_clause("1750.0") == " AS OF SYSTEM TIME '1750.0'"
+
+def test_interval_value():
+    assert aost_clause("-30s") == " AS OF SYSTEM TIME '-30s'"
+
+def test_quote_escaping():
+    assert aost_clause("a'b") == " AS OF SYSTEM TIME 'a''b'"
+```
+
+- [ ] **Step 2: Run → fail** (`pytest tests/test_aost.py -q`).
+
+- [ ] **Step 3: Implement** in `crdb_dump/utils/common.py`:
+
+```python
+def aost_clause(resolved_value):
+    """Return an ' AS OF SYSTEM TIME ...' SQL fragment, or '' when no AOST."""
+    if not resolved_value:
+        return ""
+    escaped = str(resolved_value).replace("'", "''")
+    return f" AS OF SYSTEM TIME '{escaped}'"
+```
+
+- [ ] **Step 4: Run → pass.**
+
+- [ ] **Step 5: Commit** `git commit -m "Add aost_clause() AS OF SYSTEM TIME formatter"`.
+
+---
+
+## Task 2: CLI option
+
+**Files:** Modify `crdb_dump/cli.py`
+
+- [ ] **Step 1:** Add the option to the `export` command (near `--data-*` options):
+
+```python
+@click.option('--as-of-system-time', 'aost', is_flag=False, flag_value='auto',
+              default=None,
+              help="Read data at a consistent snapshot. The bare flag pins one "
+                   "cluster_logical_timestamp(); or pass a value like '-30s', a "
+                   "timestamp, or a decimal.")
+```
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `python -m crdb_dump.cli export --help | grep -A2 as-of-system-time`
+Expected: the option appears.
+
+- [ ] **Step 3: Commit** `git commit -m "Add --as-of-system-time option to export"`.
+
+---
+
+## Task 3: Resolve/pin in `export_data` + apply in `export_table_data` + manifest
+
+**Files:** Modify `crdb_dump/export/data.py`; Test `tests/test_data_export.py`
+
+- [ ] **Step 1: Failing test** (manifest records AOST; clause used). Append to `tests/test_data_export.py`:
+
+```python
+def test_export_table_data_records_aost(tmp_path):
+    cols = [("id",)]
+    page1 = [(1,)]
+    captured = {"stmts": []}
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    def execute(stmt, *a, **k):
+        captured["stmts"].append(str(stmt))
+        s = str(stmt)
+        if "information_schema.columns" in s:
+            return iter(cols)
+        return MagicMock(fetchall=lambda: page1 if "OFFSET 0 " in s else [])
+    conn.execute.side_effect = execute
+    engine = MagicMock()
+    engine.connect.return_value = conn
+    import json, os
+    opts = {"aost_resolved": "1750.0"}
+    data_mod.export_table_data(
+        engine, "cp.cpkit.tasks", str(tmp_path), "sql", False, None, False,
+        None, False, 1000, False, logging.getLogger("t"), {}, 1, 0.0, opts)
+    manifest = json.load(open(tmp_path / "cp.cpkit.tasks.manifest.json"))
+    assert manifest["as_of_system_time"] == "1750.0"
+    assert any("AS OF SYSTEM TIME '1750.0'" in s for s in captured["stmts"])
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement in `export_table_data`:**
+
+Add near the top (after `obj = parse_object_name(...)`):
+```python
+from crdb_dump.utils.common import aost_clause   # add to imports at top of file
+clause = aost_clause(opts.get("aost_resolved"))
+```
+Column query — append `clause`:
+```python
+cols_res = conn.execute(text(
+    "SELECT column_name FROM information_schema.columns "
+    "WHERE table_name = :t AND table_schema = :s ORDER BY ordinal_position" + clause
+), {"t": obj.table, "s": obj.schema})
+```
+Row query — insert `clause` after the table:
+```python
+query = f"SELECT * FROM {obj.fq_quoted()}{clause} {order_clause} OFFSET {offset} LIMIT {batch_size}"
+```
+Manifest — add the field:
+```python
+json.dump({
+    "table": obj.fq_plain(),
+    "as_of_system_time": opts.get("aost_resolved"),
+    "region": region,
+    "chunks": manifest
+}, mf, indent=2)
+```
+
+- [ ] **Step 4: Resolve/pin once in `export_data`** (before building `data_tasks`):
+
+```python
+aost = opts.get("aost")
+if aost == "auto":
+    with engine.connect() as conn:
+        aost = str(conn.execute(text("SELECT cluster_logical_timestamp()")).scalar())
+opts["aost_resolved"] = aost
+```
+(`text` is already imported in data.py.)
+
+- [ ] **Step 5: Run → pass** (`pytest tests/test_data_export.py -q`).
+
+- [ ] **Step 6: Verify AOST on information_schema empirically**
+
+Run against the live cluster:
+```bash
+python - <<'PY'
+import os
+from sqlalchemy import create_engine, text
+e = create_engine(os.environ["CRDB_URL"])
+with e.connect() as c:
+    ts = str(c.execute(text("SELECT cluster_logical_timestamp()")).scalar())
+    try:
+        c.execute(text("SELECT column_name FROM information_schema.columns "
+                       "WHERE table_name='users' AND table_schema='public' "
+                       f"ORDER BY ordinal_position AS OF SYSTEM TIME '{ts}'")).fetchall()
+        print("AOST on information_schema: OK")
+    except Exception as ex:
+        print("AOST on information_schema: REJECTED:", str(ex)[:120])
+PY
+```
+If REJECTED: change the column query to apply `clause` only to a real-table read,
+or drop `clause` from the column query and document the skew. Re-run unit tests.
+
+- [ ] **Step 7: Commit** `git commit -m "Pin AS OF SYSTEM TIME across data export; record in manifest"`.
+
+---
+
+## Task 4: Integration tests
+
+**Files:** Modify `tests/test_integration.py`
+
+- [ ] **Step 1: Add consistency + bare-flag tests:**
+
+```python
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_aost_excludes_later_writes(tmp_path):
+    conn = get_psycopg_connection(); cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS aost_t")
+    cur.execute("CREATE TABLE aost_t (id INT PRIMARY KEY)")
+    cur.execute("INSERT INTO aost_t VALUES (1), (2)")
+    conn.commit()
+    cur.execute("SELECT cluster_logical_timestamp()")
+    ts = str(cur.fetchone()[0])
+    cur.execute("INSERT INTO aost_t VALUES (3)")  # after the snapshot
+    conn.commit(); cur.close(); conn.close()
+
+    out = tmp_path / "out"
+    r = CliRunner().invoke(main, [
+        "export", "--db=defaultdb", "--tables=public.aost_t",
+        "--data", "--data-format=csv", f"--as-of-system-time={ts}",
+        f"--out-dir={out}"])
+    assert r.exit_code == 0, r.output
+    import json
+    db_dir = out / "defaultdb"
+    manifest = json.load(open(db_dir / "defaultdb.public.aost_t.manifest.json"))
+    assert manifest["as_of_system_time"] == ts
+    rows = sum(c["rows"] for c in manifest["chunks"])
+    assert rows == 2  # row id=3 (inserted after ts) excluded
+
+
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_aost_bare_flag_pins_timestamp(tmp_path):
+    conn = get_psycopg_connection(); cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS aost_b")
+    cur.execute("CREATE TABLE aost_b (id INT PRIMARY KEY)")
+    cur.execute("INSERT INTO aost_b VALUES (1)")
+    conn.commit(); cur.close(); conn.close()
+
+    out = tmp_path / "out"
+    r = CliRunner().invoke(main, [
+        "export", "--db=defaultdb", "--tables=public.aost_b",
+        "--data", "--data-format=csv", "--as-of-system-time", f"--out-dir={out}"])
+    assert r.exit_code == 0, r.output
+    import json
+    manifest = json.load(open(out / "defaultdb" / "defaultdb.public.aost_b.manifest.json"))
+    assert manifest["as_of_system_time"]  # populated with a pinned timestamp
+```
+
+- [ ] **Step 2: Run integration**
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+pytest -m integration -q
+```
+Expected: pass.
+
+- [ ] **Step 3: Commit** `git commit -m "Integration tests for --as-of-system-time"`.
+
+---
+
+## Task 5: E2E + docs + changelog
+
+**Files:** Modify `test-local.sh`, `docs/guides/export-data.md`, `docs/guides/migration-limitations.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: Add an AOST step to `test-local.sh`** after the main export section:
+
+```bash
+echo "🕒 Testing --as-of-system-time (consistent snapshot)..."
+$CRDB_DUMP --verbose export --db="$DB_NAME" --tables=public.users \
+  --data --data-format=csv --as-of-system-time --out-dir="$OUT_DIR/aost"
+python - "$OUT_DIR/aost/$DB_NAME/${DB_NAME}.public.users.manifest.json" <<'PY'
+import json, sys
+m = json.load(open(sys.argv[1]))
+assert m.get("as_of_system_time"), "manifest missing as_of_system_time"
+print("✅ AOST timestamp recorded:", m["as_of_system_time"])
+PY
+```
+
+- [ ] **Step 2: Docs** — add an AOST section to `docs/guides/export-data.md`:
+
+```markdown
+## Consistent snapshots (`--as-of-system-time`)
+
+By default each table is read independently, so a dump of a live database is not
+consistent across tables. Use `--as-of-system-time` to read every table at one
+pinned cluster timestamp:
+
+```bash
+# pin one cluster_logical_timestamp() for the whole export
+crdb-dump export --db=mydb --data --as-of-system-time
+
+# or pass an explicit interval / timestamp / decimal
+crdb-dump export --db=mydb --data --as-of-system-time='-30s'
+```
+
+The pinned timestamp is recorded in each manifest as `as_of_system_time`.
+
+!!! warning
+    The timestamp must be within the table's garbage-collection window
+    (`gc.ttlseconds`). Very long exports against an old timestamp can fail.
+```
+
+- [ ] **Step 3: Docs** — in `docs/guides/migration-limitations.md`, change the
+"planned enhancement" note to state AOST is available via `--as-of-system-time`,
+keeping the GC-window caveat.
+
+- [ ] **Step 4: Changelog** — under `## Unreleased`, replace `_No changes yet._` with:
+
+```markdown
+### Added
+- `--as-of-system-time` on `export`: read all table data at one pinned cluster
+  timestamp for a consistent point-in-time snapshot. The bare flag pins
+  `cluster_logical_timestamp()`; an explicit value is used verbatim. The pinned
+  timestamp is recorded in each manifest.
+```
+
+- [ ] **Step 5: Run full suite + e2e**
+
+```bash
+pytest -q                      # unit + integration (CRDB_URL set)
+./test-local.sh                # e2e incl. AOST assertion
+mkdocs build --strict          # docs still build
+```
+Expected: all green.
+
+- [ ] **Step 6: Commit** `git commit -m "E2E + docs + changelog for --as-of-system-time"`.
+
+---
+
+## Task 6: PR
+
+- [ ] **Step 1:** `git push -u origin aost`
+- [ ] **Step 2:** Open PR describing the option, consistency semantics, manifest field, and tests.
+
+---
+
+## Self-Review notes
+
+- Spec coverage: formatter (T1), CLI (T2), pin+apply+manifest (T3), integration (T4), e2e+docs+changelog (T5), PR (T6).
+- The information_schema AOST verification (T3 Step 6) gates whether the column
+  query keeps the clause; fallback documented.
+- Types/names consistent: `aost_clause`, `opts["aost"]`/`opts["aost_resolved"]`,
+  manifest key `as_of_system_time`.

--- a/docs/superpowers/specs/2026-06-26-as-of-system-time-design.md
+++ b/docs/superpowers/specs/2026-06-26-as-of-system-time-design.md
@@ -1,0 +1,154 @@
+# `--as-of-system-time` for Consistent Data Exports (Design)
+
+Date: 2026-06-26
+Status: Approved
+
+## Problem
+
+crdb-dump reads each table independently with `OFFSET`/`LIMIT` and no
+`AS OF SYSTEM TIME`. A dump taken while the database is being written is therefore
+not a transactionally consistent snapshot across (or even within) tables. This
+limits its usefulness for clones and with-downtime migrations.
+
+## Goal
+
+Add an option to read all table data at a single, pinned cluster timestamp so a
+dump is a consistent point-in-time snapshot.
+
+## Decisions (from brainstorming, approved)
+
+- **Flag:** `--as-of-system-time` on `export`, with an optional value.
+  - Bare `--as-of-system-time` → `aost="auto"`: capture one
+    `cluster_logical_timestamp()` at export start and reuse it for every table and
+    every chunk.
+  - `--as-of-system-time=<value>` → used verbatim (e.g. `-30s`, a timestamp, a
+    decimal).
+  - Omitted → `None` (current behavior, no AOST).
+- **Consistency:** the value is resolved/pinned **once** in `export_data` and
+  applied to all queries.
+- **Scope:** applied to the row `SELECT`s and the column-discovery query, so the
+  column list matches the snapshot. Schema DDL (`SHOW CREATE`) reads at current
+  time — CockroachDB does not support `AS OF SYSTEM TIME` there; this is a
+  **data**-consistency guarantee.
+- **Traceability:** the pinned timestamp is recorded in each manifest as
+  `as_of_system_time`.
+
+## Architecture
+
+### CLI (`crdb_dump/cli.py`)
+
+Add to the `export` command:
+
+```python
+@click.option('--as-of-system-time', 'aost', is_flag=False, flag_value='auto',
+              default=None,
+              help="Read data at a consistent snapshot. The bare flag pins one "
+                   "cluster_logical_timestamp(); or pass a value like '-30s', a "
+                   "timestamp, or a decimal.")
+```
+
+`flag_value='auto'` makes the bare flag yield `"auto"`; `--as-of-system-time=-30s`
+yields `"-30s"`; omission yields `None`. The value lands in `kwargs`/`opts` as
+`aost`.
+
+### Clause helper (`crdb_dump/utils/common.py`)
+
+A pure formatter, unit-testable without a database:
+
+```python
+def aost_clause(resolved_value):
+    """Return an ' AS OF SYSTEM TIME ...' SQL fragment, or '' when no AOST."""
+    if not resolved_value:
+        return ""
+    escaped = str(resolved_value).replace("'", "''")
+    return f" AS OF SYSTEM TIME '{escaped}'"
+```
+
+Uniform single-quoting works for decimals, intervals (`-30s`), and timestamps.
+
+### Resolution + pinning (`crdb_dump/export/data.py`, `export_data`)
+
+Before exporting any table, resolve the value exactly once:
+
+```python
+aost = opts.get("aost")
+if aost == "auto":
+    with engine.connect() as conn:
+        aost = str(conn.execute(text("SELECT cluster_logical_timestamp()")).scalar())
+opts["aost_resolved"] = aost            # None or a fixed string, reused everywhere
+```
+
+`export_table_data` already receives `opts`, so it reads `opts["aost_resolved"]`
+and computes `clause = aost_clause(opts.get("aost_resolved"))` once.
+
+### Applying the clause (`export_table_data`)
+
+- Column query:
+  ```sql
+  SELECT column_name FROM information_schema.columns
+  WHERE table_name = :t AND table_schema = :s ORDER BY ordinal_position
+  ```
+  becomes `... ORDER BY ordinal_position{clause}` (clause appended).
+- Row query:
+  ```sql
+  SELECT * FROM <fq>{clause} {order_clause} OFFSET <o> LIMIT <n>
+  ```
+  The `AS OF SYSTEM TIME` fragment goes immediately after the table reference and
+  before `ORDER BY`/`OFFSET`/`LIMIT`.
+
+**Implementation check:** verify empirically that `AS OF SYSTEM TIME` is accepted
+on the `information_schema.columns` query (a virtual table). If CockroachDB rejects
+it, fall back to running the column query at current time and document the minor
+skew risk; the row-level snapshot guarantee is unaffected.
+
+### Manifest (`export_table_data`)
+
+Add the pinned timestamp:
+
+```json
+{
+  "table": "mydb.public.users",
+  "as_of_system_time": "1750000000.0000000000",
+  "region": "N/A",
+  "chunks": [ ... ]
+}
+```
+
+`as_of_system_time` is `null` when AOST is not used.
+
+## Error handling
+
+- An AOST timestamp older than the table's GC TTL fails the query with a clear
+  CockroachDB error; this surfaces through the existing per-table error handling
+  and is documented as a caveat (keep exports shorter than the GC window, or raise
+  `gc.ttlseconds`).
+- Function-expression values (e.g. `follower_read_timestamp()`) are out of scope —
+  the quoted-value model treats inputs as AOST string literals.
+
+## Testing (all three levels)
+
+- **Unit** (`tests/test_aost.py`): `aost_clause(None)` → `""`;
+  `aost_clause("1750.0")` → `" AS OF SYSTEM TIME '1750.0'"`;
+  `aost_clause("-30s")` → `" AS OF SYSTEM TIME '-30s'"`; quote escaping.
+- **Integration** (`tests/test_integration.py`, gated on `CRDB_URL`):
+  capture `cluster_logical_timestamp()`, insert a new row *after* it, export the
+  table with `--as-of-system-time=<captured>` → the new row is **excluded**, and
+  the manifest records `as_of_system_time`. Also a bare-flag `--as-of-system-time`
+  smoke test (export succeeds, manifest timestamp populated).
+- **E2E** (`test-local.sh`): add a step that exports with `--as-of-system-time`
+  and asserts the manifest contains `as_of_system_time`.
+
+## Docs
+
+- `docs/guides/export-data.md`: add an "As-of-system-time (consistent snapshots)"
+  section.
+- `docs/guides/migration-limitations.md`: flip the consistency caveat from "planned
+  enhancement" to "available via `--as-of-system-time`", keeping the GC-window note.
+- `CHANGELOG.md`: add under `Unreleased` → Added.
+
+## Out of scope
+
+- AOST on schema DDL (`SHOW CREATE`) — unsupported by CockroachDB.
+- Function-expression AOST values.
+- Applying AOST to `collect_objects`/locality discovery (object set is not part of
+  the data-snapshot guarantee).

--- a/test-local.sh
+++ b/test-local.sh
@@ -182,6 +182,16 @@ test -f "$BASE_OUT_DIR/${DB_NAME}.public.embeddings.manifest.json" \
   && echo "✅ VECTOR table (embeddings) exported" \
   || { echo "❌ VECTOR table NOT exported"; exit 1; }
 
+echo "🕒 Testing --as-of-system-time (consistent snapshot)..."
+$CRDB_DUMP --verbose export --db="$DB_NAME" --tables=public.users \
+  --data --data-format=csv --as-of-system-time --out-dir="$OUT_DIR/aost"
+$PYTHON - "$OUT_DIR/aost/$DB_NAME/${DB_NAME}.public.users.manifest.json" <<'PY'
+import json, sys
+m = json.load(open(sys.argv[1]))
+assert m.get("as_of_system_time"), "manifest missing as_of_system_time"
+print("✅ AOST timestamp recorded:", m["as_of_system_time"])
+PY
+
 echo "🧪 Verifying chunks..."
 $CRDB_DUMP --verbose export \
   --db="$DB_NAME" \

--- a/tests/test_aost.py
+++ b/tests/test_aost.py
@@ -1,0 +1,21 @@
+from crdb_dump.utils.common import aost_clause
+
+
+def test_none_returns_empty():
+    assert aost_clause(None) == ""
+
+
+def test_empty_returns_empty():
+    assert aost_clause("") == ""
+
+
+def test_decimal_value():
+    assert aost_clause("1750.0") == " AS OF SYSTEM TIME '1750.0'"
+
+
+def test_interval_value():
+    assert aost_clause("-30s") == " AS OF SYSTEM TIME '-30s'"
+
+
+def test_quote_escaping():
+    assert aost_clause("a'b") == " AS OF SYSTEM TIME 'a''b'"

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -33,3 +33,33 @@ def test_export_table_data_three_part_naming(tmp_path):
     sql_file = [f for f in files if f.endswith(".sql")][0]
     content = (tmp_path / sql_file).read_text()
     assert 'INSERT INTO "cp"."cpkit"."tasks"' in content
+
+
+def test_export_table_data_records_aost(tmp_path):
+    cols = [("id",)]
+    page1 = [(1,)]
+    captured = {"stmts": []}
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+
+    def execute(stmt, *a, **k):
+        s = str(stmt)
+        captured["stmts"].append(s)
+        if "information_schema.columns" in s:
+            return iter(cols)
+        return MagicMock(fetchall=lambda: page1 if "OFFSET 0 " in s else [])
+
+    conn.execute.side_effect = execute
+    conn.execution_options.return_value = conn  # AUTOCOMMIT branch returns same conn
+    engine = MagicMock()
+    engine.connect.return_value = conn
+
+    opts = {"aost_resolved": "1750.0"}
+    data_mod.export_table_data(
+        engine, "cp.cpkit.tasks", str(tmp_path), "sql", False, None, False,
+        None, False, 1000, False, logging.getLogger("t"), {}, 1, 0.0, opts)
+
+    manifest = json.load(open(tmp_path / "cp.cpkit.tasks.manifest.json"))
+    assert manifest["as_of_system_time"] == "1750.0"
+    assert any("AS OF SYSTEM TIME '1750.0'" in s for s in captured["stmts"])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -224,3 +224,57 @@ def test_vector_roundtrip(tmp_path):
     assert vals == ["[1.5,2,3.25]", "[0,0,0]"]
     cur.close()
     conn.close()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_aost_excludes_later_writes(tmp_path):
+    import time
+    conn = get_psycopg_connection()
+    conn.autocommit = True  # each statement its own txn so timestamps are ordered
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS aost_t")
+    cur.execute("CREATE TABLE aost_t (id INT PRIMARY KEY)")
+    cur.execute("INSERT INTO aost_t VALUES (1), (2)")
+    cur.execute("SELECT cluster_logical_timestamp()")
+    ts = str(cur.fetchone()[0])
+    time.sleep(0.5)
+    cur.execute("INSERT INTO aost_t VALUES (3)")  # committed strictly after the snapshot
+    cur.close()
+    conn.close()
+
+    out = tmp_path / "out"
+    r = CliRunner().invoke(main, [
+        "export", "--db=defaultdb", "--tables=public.aost_t",
+        "--data", "--data-format=csv", f"--as-of-system-time={ts}",
+        f"--out-dir={out}"])
+    assert r.exit_code == 0, r.output
+
+    import json
+    manifest = json.load(open(out / "defaultdb" / "defaultdb.public.aost_t.manifest.json"))
+    assert manifest["as_of_system_time"] == ts
+    rows = sum(c["rows"] for c in manifest["chunks"])
+    assert rows == 2  # row id=3 (inserted after ts) is excluded
+
+
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_aost_bare_flag_pins_timestamp(tmp_path):
+    conn = get_psycopg_connection()
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS aost_b")
+    cur.execute("CREATE TABLE aost_b (id INT PRIMARY KEY)")
+    cur.execute("INSERT INTO aost_b VALUES (1)")
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    out = tmp_path / "out"
+    r = CliRunner().invoke(main, [
+        "export", "--db=defaultdb", "--tables=public.aost_b",
+        "--data", "--data-format=csv", "--as-of-system-time", f"--out-dir={out}"])
+    assert r.exit_code == 0, r.output
+
+    import json
+    manifest = json.load(open(out / "defaultdb" / "defaultdb.public.aost_b.manifest.json"))
+    assert manifest["as_of_system_time"]  # populated with a pinned timestamp


### PR DESCRIPTION
## Summary

Adds `--as-of-system-time` to `crdb-dump export` so a dump can be a consistent point-in-time snapshot — the main gap that kept crdb-dump from being safe for live-ish clones/migrations.

- **Flag:** `--as-of-system-time` (optional value). Bare flag pins one `cluster_logical_timestamp()` at export start; an explicit value (`-30s`, a timestamp, or a decimal) is used verbatim; omitted = today's behavior.
- **Consistency:** the value is resolved/pinned **once** and applied to every table and every chunk. Reads run in **AUTOCOMMIT** so each query is its own transaction at the same pinned timestamp (CockroachDB allows only one `AS OF SYSTEM TIME` per transaction).
- **Scope:** row `SELECT`s and the column-discovery query (so columns match the snapshot). Schema DDL is unaffected (CRDB doesn't support AOST on `SHOW CREATE`).
- **Traceability:** the pinned timestamp is recorded in each manifest as `as_of_system_time`.

## Testing

- **Unit:** `aost_clause()` formatter.
- **Integration (live CRDB):** capture a timestamp, insert a row *after* it, export `--as-of-system-time=<ts>` → the new row is **excluded** and the manifest records the ts; bare-flag smoke test.
- **E2E:** `test-local.sh` exports with `--as-of-system-time` and asserts the manifest timestamp.
- Full suite green; `mkdocs build --strict` clean.

Verified against a real cluster (caught and fixed a SQL-placement bug and the per-transaction AOST conflict during testing).

## Docs

- New "Consistent snapshots" section in the Export Data guide.
- Migration & Limitations updated from "planned" to "available".
- CHANGELOG `Unreleased` → Added.