### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+_No changes yet._
+
+## 0.5.0 — 2026-06-26
+
 ### Added
 - `--as-of-system-time` on `export`: read all table data at one pinned cluster
   timestamp for a consistent point-in-time snapshot. The bare flag pins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crdb-dump"
-version = "0.4.0"
+version = "0.5.0"
 description = "A CLI tool to export and import schema definitions and data from CockroachDB in SQL, JSON, YAML, or chunked CSV formats."
 
 authors = [


### PR DESCRIPTION
Prepares the 0.5.0 release.

- Bumps `version` in `pyproject.toml` to `0.5.0`.
- Dates the CHANGELOG: `## Unreleased` → `## 0.5.0 — 2026-06-26`, with a fresh empty `Unreleased` section.

0.5.0 adds `--as-of-system-time` (consistent point-in-time exports, merged in #6) on top of the 0.4.0 schema-aware overhaul.

## To cut the release after merge

Run the **Release** workflow with version `0.5.0`. The version-guard matches `pyproject.toml` (verified locally: installed package reports `0.5.0`); it runs the full test suite against a CockroachDB container, builds, publishes to PyPI via Trusted Publishing, and creates the `v0.5.0` GitHub Release.