### PR TITLE
Ignore .cache/ (mkdocs build cache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ resume/
 heap_profiler/
 cockroach-data/
 site/
+
+# mkdocs-material build cache (social cards, etc.)
+.cache/


### PR DESCRIPTION
Adds `.cache/` to `.gitignore` so MkDocs Material's social-card build cache (`.cache/plugin/social/`) doesn't show up as untracked after local docs builds. Housekeeping only.