### PR TITLE
Add --as-of-system-time=follower (follower reads)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-_No changes yet._
+### Added
+- `--as-of-system-time=follower`: pin `follower_read_timestamp()` so exports are
+  served by the nearest replica (follower reads), keeping the consistent-snapshot
+  guarantee. Reads use default priority to stay low-impact. Fails fast with a clear
+  message if the cluster lacks the follower-reads entitlement.
 
 ## 0.5.0 — 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+_No changes yet._
+
+## 0.6.0 — 2026-06-26
+
 ### Added
 - `--as-of-system-time=follower`: pin `follower_read_timestamp()` so exports are
   served by the nearest replica (follower reads), keeping the consistent-snapshot

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Tests](https://github.com/viragtripathi/crdb-dump/actions/workflows/python-ci.yml/badge.svg)](https://github.com/viragtripathi/crdb-dump/actions/workflows/python-ci.yml)
 [![PyPI version](https://badge.fury.io/py/crdb-dump.svg)](https://badge.fury.io/py/crdb-dump)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Downloads](https://static.pepy.tech/badge/crdb-dump/month)](https://pepy.tech/project/crdb-dump)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/crdb-dump?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/crdb-dump)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue.svg)](https://viragtripathi.github.io/crdb-dump/)
 

--- a/crdb_dump/cli.py
+++ b/crdb_dump/cli.py
@@ -50,9 +50,10 @@ def main(ctx, verbose):
 @click.option('--data-order-strict', is_flag=True, help='Fail if ordered column(s) not found')
 @click.option('--chunk-size', type=int, default=None, help='Rows per CSV chunk')
 @click.option('--as-of-system-time', 'aost', is_flag=False, flag_value='auto', default=None,
-              help="Read data at a consistent snapshot. The bare flag pins one "
-                   "cluster_logical_timestamp(); or pass a value like '-30s', a "
-                   "timestamp, or a decimal.")
+              help="Read data at a consistent snapshot. Use 'auto' (or the bare flag) "
+                   "to pin cluster_logical_timestamp(), 'follower' to pin "
+                   "follower_read_timestamp() for follower reads, or pass a value like "
+                   "'-30s', a timestamp, or a decimal.")
 @click.option('--verify', is_flag=True, help='Verify exported chunk checksums')
 @click.option('--verify-strict', is_flag=True, help='Stop if any checksum fails')
 @click.option('--out-dir', default='crdb_dump_output', help='Output directory for all exports')

--- a/crdb_dump/export/data.py
+++ b/crdb_dump/export/data.py
@@ -3,6 +3,7 @@ import gzip
 import hashlib
 import json
 import os
+import click
 from crdb_dump.utils.common import retry, get_table_locality
 from crdb_dump.utils.s3 import get_s3_client, upload_file_to_s3
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -151,6 +152,16 @@ def export_data(opts, out_dir, logger):
     if aost == "auto":
         with engine.connect() as conn:
             aost = str(conn.execute(text("SELECT cluster_logical_timestamp()")).scalar())
+    elif aost == "follower":
+        try:
+            with engine.connect() as conn:
+                aost = str(conn.execute(text("SELECT follower_read_timestamp()")).scalar())
+        except Exception as e:
+            raise click.UsageError(
+                "Follower reads are not available on this cluster "
+                "(requires a CockroachDB entitlement that enables follower reads): "
+                f"{e}")
+    if aost is not None:
         logger.info(f"🕒 Pinned AS OF SYSTEM TIME {aost}")
     opts["aost_resolved"] = aost
 

--- a/crdb_dump/export/data.py
+++ b/crdb_dump/export/data.py
@@ -154,8 +154,13 @@ def export_data(opts, out_dir, logger):
             aost = str(conn.execute(text("SELECT cluster_logical_timestamp()")).scalar())
     elif aost == "follower":
         try:
+            # Cast to CRDB's native timestamp string (e.g. '2026-06-26 19:20:03.25+00')
+            # which AOST accepts. The raw timestamptz would be reformatted by the
+            # driver to '+00:00' (rejected), and ::DECIMAL is in seconds, not the
+            # nanosecond scale AOST decimals use.
             with engine.connect() as conn:
-                aost = str(conn.execute(text("SELECT follower_read_timestamp()")).scalar())
+                aost = str(conn.execute(
+                    text("SELECT follower_read_timestamp()::STRING")).scalar())
         except Exception as e:
             raise click.UsageError(
                 "Follower reads are not available on this cluster "

--- a/docs/guides/export-data.md
+++ b/docs/guides/export-data.md
@@ -62,8 +62,9 @@ The pinned timestamp is recorded in each manifest as `as_of_system_time`.
 
 !!! warning
     The timestamp must be within the table's garbage-collection window
-    (`gc.ttlseconds`). A very long export against an old timestamp can fail once
-    the snapshot ages out of GC.
+    ([`gc.ttlseconds`](https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds)).
+    A very long export against an old timestamp can fail once the snapshot ages out
+    of GC.
 
 ### Follower reads
 

--- a/docs/guides/export-data.md
+++ b/docs/guides/export-data.md
@@ -62,8 +62,37 @@ The pinned timestamp is recorded in each manifest as `as_of_system_time`.
 
 !!! warning
     The timestamp must be within the table's garbage-collection window
-    (`gc.ttlseconds`, default 25h). A very long export against an old timestamp
-    can fail once the snapshot ages out of GC.
+    (`gc.ttlseconds`). A very long export against an old timestamp can fail once
+    the snapshot ages out of GC.
+
+### Follower reads
+
+Use `follower` to read from the **nearest replica** instead of the leaseholder,
+reducing impact on the live workload (and cross-region latency). It pins
+`follower_read_timestamp()` once and reuses it for the whole export:
+
+```bash
+crdb-dump export --db=mydb --data --as-of-system-time=follower
+```
+
+This still produces a consistent snapshot (one pinned timestamp, recorded in each
+manifest). Reads use default priority to stay low-impact, so a read may
+occasionally wait briefly on an unresolved write intent.
+
+!!! note "Requirements & caveats"
+    - Requires a CockroachDB entitlement that enables follower reads. Without it,
+      the export fails fast with a clear message rather than silently reading from
+      the leaseholder.
+    - `follower_read_timestamp()` returns a timestamp **slightly in the past**
+      (CockroachDB's guidance is to use exact-staleness reads when you can tolerate
+      data at least a few seconds old). Objects created in the last few seconds may
+      not be visible at that timestamp — a non-issue for normal exports of existing
+      data. See the [CockroachDB follower-reads docs](https://www.cockroachlabs.com/docs/stable/follower-reads)
+      for current details.
+    - Actual follower routing requires a multi-node cluster; on a single node the
+      read is served locally. Verify with
+      `EXPLAIN ANALYZE SELECT … AS OF SYSTEM TIME follower_read_timestamp()`
+      (look for `used follower read`).
 
 ## Verifying
 

--- a/docs/guides/migration-limitations.md
+++ b/docs/guides/migration-limitations.md
@@ -42,7 +42,8 @@ consistent snapshot across tables.
     ```
 
     The timestamp must stay within the garbage-collection window
-    (`gc.ttlseconds`), so keep exports shorter than that window or raise the TTL.
+    ([`gc.ttlseconds`](https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds)),
+    so keep exports shorter than that window or raise the TTL.
 
 ## Further reading
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/viragtripathi/crdb-dump/actions/workflows/python-ci.yml/badge.svg)](https://github.com/viragtripathi/crdb-dump/actions/workflows/python-ci.yml)
 [![PyPI version](https://badge.fury.io/py/crdb-dump.svg)](https://badge.fury.io/py/crdb-dump)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Downloads](https://static.pepy.tech/badge/crdb-dump/month)](https://pepy.tech/project/crdb-dump)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/crdb-dump?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/crdb-dump)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **Export and import CockroachDB schemas and data — SQL, JSON, YAML, or chunked CSV.**

--- a/docs/superpowers/plans/2026-06-26-follower-reads.md
+++ b/docs/superpowers/plans/2026-06-26-follower-reads.md
@@ -1,0 +1,313 @@
+# `--as-of-system-time=follower` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Steps use checkbox (`- [ ]`).
+
+**Goal:** Add `--as-of-system-time=follower`, which pins `follower_read_timestamp()` once so exports are served by the nearest replica (follower reads) while keeping the existing consistency guarantee.
+
+**Architecture:** One new branch in the existing pin-once resolution in `export_data` resolves `follower` to `SELECT follower_read_timestamp()`, reusing the existing `aost_clause()` + AUTOCOMMIT read path. Fail fast with a clean message if the cluster lacks the entitlement.
+
+**Tech Stack:** Python, Click, SQLAlchemy, pytest, CockroachDB v25.4.
+
+## Global Constraints
+
+- Keyword: `--as-of-system-time=follower` (reuse the existing option; mirrors `auto`).
+- Keep AUTOCOMMIT reads at the pinned timestamp; default priority (no `PRIORITY HIGH`).
+- Resolve/pin once; reuse for every table and chunk (consistency).
+- On entitlement failure: raise `click.UsageError` with a clear message, no traceback, no silent leaseholder fallback.
+- Verify follower routing empirically via `EXPLAIN ANALYZE` (`used follower read`).
+- Tests at all three levels, entitlement-tolerant. Plain commit messages.
+- Build/verify in repo `.venv`; live CRDB on `localhost:26257`.
+
+---
+
+## Task 0: Empirical pre-check (shapes the tests)
+
+**Files:** none (investigation)
+
+- [ ] **Step 1: Start a local cluster**
+
+```bash
+cockroach start-single-node --insecure --store=type=mem,size=1GiB \
+  --listen-addr=localhost:26257 --http-addr=localhost:8081 --background
+sleep 4
+```
+
+- [ ] **Step 2: Does `follower_read_timestamp()` work here, and does it route to a follower?**
+
+```bash
+cockroach sql --insecure --host=localhost -d defaultdb -e "
+  CREATE TABLE IF NOT EXISTS fr_probe (id INT PRIMARY KEY);
+  INSERT INTO fr_probe VALUES (1) ON CONFLICT DO NOTHING;
+  SELECT follower_read_timestamp();
+"
+cockroach sql --insecure --host=localhost -d defaultdb -e "
+  EXPLAIN ANALYZE SELECT * FROM fr_probe AS OF SYSTEM TIME follower_read_timestamp();
+" | grep -i "follower read" || echo "no 'used follower read' line"
+```
+Record the outcome:
+- If `follower_read_timestamp()` errors (entitlement) → the integration/e2e tests
+  assert the clean-error path.
+- If it succeeds → tests also assert success + (single node may NOT show
+  `used follower read`, since there are no followers; note that and rely on the
+  multi-node behavior being documented rather than asserted on one node).
+
+---
+
+## Task 1: Resolve `follower` + error handling + CLI help
+
+**Files:**
+- Modify: `crdb_dump/export/data.py` (resolution block; add `import click`)
+- Modify: `crdb_dump/cli.py` (help text)
+- Test: `tests/test_data_export.py`
+
+**Interfaces:**
+- Consumes: existing `opts["aost"]`, `opts["aost_resolved"]`, `aost_clause()`.
+- Produces: `export_data` resolves `opts["aost"]=="follower"` to a pinned decimal via
+  `SELECT follower_read_timestamp()`, or raises `click.UsageError`.
+
+- [ ] **Step 1: Write failing unit tests**
+
+```python
+# append to tests/test_data_export.py
+import click
+import pytest
+from sqlalchemy import text  # noqa: F401  (kept for clarity)
+
+
+def _engine_returning_scalar(value=None, raises=None):
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    if raises is not None:
+        conn.execute.side_effect = raises
+    else:
+        conn.execute.return_value = MagicMock(scalar=lambda: value)
+    engine = MagicMock()
+    engine.connect.return_value = conn
+    return engine
+
+
+def test_export_data_resolves_follower(monkeypatch, tmp_path):
+    engine = _engine_returning_scalar(value="1750.5")
+    monkeypatch.setattr(data_mod, "get_sqlalchemy_engine", lambda opts: engine)
+    monkeypatch.setattr(data_mod, "get_table_locality", lambda e, db, lg: {})
+    # no tables -> collect_objects returns []; export loop is a no-op
+    monkeypatch.setattr(data_mod, "collect_objects", lambda *a, **k: [])
+    opts = {"db": "d", "tables": None, "aost": "follower", "region": None,
+            "data_format": "csv", "data_split": False, "data_limit": None,
+            "data_compress": False, "data_order": None, "data_order_desc": False,
+            "chunk_size": 1000, "data_order_strict": False, "data_parallel": False,
+            "retry_count": 1, "retry_delay": 0}
+    data_mod.export_data(opts, str(tmp_path), logging.getLogger("t"))
+    assert opts["aost_resolved"] == "1750.5"
+
+
+def test_export_data_follower_unavailable_raises(monkeypatch, tmp_path):
+    engine = _engine_returning_scalar(raises=Exception("requires enterprise"))
+    monkeypatch.setattr(data_mod, "get_sqlalchemy_engine", lambda opts: engine)
+    monkeypatch.setattr(data_mod, "get_table_locality", lambda e, db, lg: {})
+    opts = {"db": "d", "tables": None, "aost": "follower", "region": None,
+            "retry_count": 1, "retry_delay": 0}
+    with pytest.raises(click.UsageError):
+        data_mod.export_data(opts, str(tmp_path), logging.getLogger("t"))
+```
+
+- [ ] **Step 2: Run → fail** (`pytest tests/test_data_export.py -q`).
+
+- [ ] **Step 3: Implement.** In `crdb_dump/export/data.py` add `import click` near the
+top, and replace the existing resolution block:
+
+```python
+    aost = opts.get("aost")
+    if aost == "auto":
+        with engine.connect() as conn:
+            aost = str(conn.execute(text("SELECT cluster_logical_timestamp()")).scalar())
+    elif aost == "follower":
+        try:
+            with engine.connect() as conn:
+                aost = str(conn.execute(text("SELECT follower_read_timestamp()")).scalar())
+        except Exception as e:
+            raise click.UsageError(
+                "Follower reads are not available on this cluster "
+                "(requires a CockroachDB entitlement that enables follower reads): "
+                f"{e}")
+    if aost is not None:
+        logger.info(f"🕒 Pinned AS OF SYSTEM TIME {aost}")
+    opts["aost_resolved"] = aost
+```
+
+(`get_table_locality` runs before this block, as today.)
+
+- [ ] **Step 4: Update CLI help** in `crdb_dump/cli.py`:
+
+```python
+@click.option('--as-of-system-time', 'aost', is_flag=False, flag_value='auto', default=None,
+              help="Read data at a consistent snapshot. Use 'auto' (or the bare flag) "
+                   "to pin cluster_logical_timestamp(), 'follower' to pin "
+                   "follower_read_timestamp() for follower reads, or pass a value "
+                   "like '-30s', a timestamp, or a decimal.")
+```
+
+- [ ] **Step 5: Run → pass** (`pytest tests/test_data_export.py -q`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crdb_dump/export/data.py crdb_dump/cli.py tests/test_data_export.py
+git commit -m "Add --as-of-system-time=follower (pin follower_read_timestamp())"
+```
+
+---
+
+## Task 2: Integration test (entitlement-tolerant) + routing check
+
+**Files:** Modify `tests/test_integration.py`
+
+- [ ] **Step 1: Add the test**
+
+```python
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_aost_follower_keyword(tmp_path):
+    conn = get_psycopg_connection()
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS fr_t")
+    cur.execute("CREATE TABLE fr_t (id INT PRIMARY KEY)")
+    cur.execute("INSERT INTO fr_t VALUES (1), (2)")
+    cur.close()
+    conn.close()
+
+    out = tmp_path / "out"
+    r = CliRunner().invoke(main, [
+        "export", "--db=defaultdb", "--tables=public.fr_t",
+        "--data", "--data-format=csv", "--as-of-system-time=follower",
+        f"--out-dir={out}"])
+
+    if r.exit_code == 0:
+        import json
+        manifest = json.load(open(out / "defaultdb" / "defaultdb.public.fr_t.manifest.json"))
+        assert manifest["as_of_system_time"]  # a pinned follower timestamp
+    else:
+        # Cluster lacks the follower-reads entitlement: must be a clean message,
+        # not a raw traceback.
+        assert "Follower reads are not available" in r.output
+        assert "Traceback" not in r.output
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+pytest -m integration -q
+```
+Expected: pass (whichever branch the cluster takes).
+
+- [ ] **Step 3: Manually confirm routing where supported**
+
+```bash
+cockroach sql --insecure --host=localhost -d defaultdb -e "
+  EXPLAIN ANALYZE SELECT * FROM fr_t AS OF SYSTEM TIME follower_read_timestamp();" \
+  | grep -i "follower read" || echo "(single node: no follower replica to route to)"
+```
+Record the result in the PR description.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_integration.py
+git commit -m "Integration test for --as-of-system-time=follower"
+```
+
+---
+
+## Task 3: E2E + docs + changelog
+
+**Files:** Modify `test-local.sh`, `docs/guides/export-data.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: Add a tolerant follower step to `test-local.sh`** after the existing
+AOST step:
+
+```bash
+echo "🛰️  Testing --as-of-system-time=follower (tolerant of entitlement)..."
+if $CRDB_DUMP --verbose export --db="$DB_NAME" --tables=public.users \
+     --data --data-format=csv --as-of-system-time=follower \
+     --out-dir="$OUT_DIR/follower" 2>"$OUT_DIR/follower.err"; then
+  echo "✅ follower-read export succeeded"
+else
+  if grep -q "Follower reads are not available" "$OUT_DIR/follower.err"; then
+    echo "ℹ️  follower reads not entitled on this cluster — clean error, OK"
+  else
+    echo "❌ unexpected follower-read failure:"; cat "$OUT_DIR/follower.err"; exit 1
+  fi
+fi
+```
+
+- [ ] **Step 2: Docs** — in `docs/guides/export-data.md`, extend the
+consistent-snapshots section:
+
+```markdown
+### Follower reads
+
+Use `follower` to read from the nearest replica (lower impact on the live
+workload) by pinning `follower_read_timestamp()`:
+
+```bash
+crdb-dump export --db=mydb --data --as-of-system-time=follower
+```
+
+This still produces a consistent snapshot (one pinned timestamp) and records it in
+each manifest. Reads use default priority to stay low-impact, so an occasional read
+may briefly wait on an unresolved write intent.
+
+!!! note "Entitlement"
+    `follower_read_timestamp()` requires a CockroachDB entitlement that enables
+    follower reads. Without it, the export fails fast with a clear message rather
+    than silently reading from the leaseholder.
+```
+
+- [ ] **Step 3: Changelog** — under `## Unreleased`, replace `_No changes yet._` with:
+
+```markdown
+### Added
+- `--as-of-system-time=follower`: pin `follower_read_timestamp()` so exports are
+  served by the nearest replica (follower reads), keeping the consistent-snapshot
+  guarantee. Fails fast with a clear message if the cluster lacks the entitlement.
+```
+
+- [ ] **Step 4: Verify everything**
+
+```bash
+export CRDB_URL="cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+pytest -q
+./test-local.sh
+mkdocs build --strict
+```
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test-local.sh docs/guides/export-data.md CHANGELOG.md
+git commit -m "E2E + docs + changelog for --as-of-system-time=follower"
+```
+
+---
+
+## Task 4: PR
+
+- [ ] **Step 1:** `git push -u origin follower-reads`
+- [ ] **Step 2:** Open a PR describing the keyword, the AUTOCOMMIT/default-priority
+rationale, the entitlement error handling, and the routing-verification result.
+
+---
+
+## Self-Review notes
+
+- Spec coverage: resolution+error+help (T1), integration tolerant + routing (T2),
+  e2e+docs+changelog (T3), PR (T4); pre-check (T0) shapes the assertions.
+- Single-node caveat called out: `used follower read` may not appear with no
+  follower replica; we assert success/clean-error, not routing, in automated tests.
+- Names consistent: `opts["aost"]` value `"follower"`, `opts["aost_resolved"]`,
+  `aost_clause`, manifest `as_of_system_time`, `click.UsageError`.
+```

--- a/docs/superpowers/specs/2026-06-26-follower-reads-design.md
+++ b/docs/superpowers/specs/2026-06-26-follower-reads-design.md
@@ -1,0 +1,128 @@
+# `--as-of-system-time=follower` (Follower Reads) Design
+
+Date: 2026-06-26
+Status: Approved-pending-review
+
+## Problem
+
+Exporting a large database from a live cluster reads from the leaseholder
+(now unified with the Raft leader under **Leader Leases**, v25.2), competing with
+the foreground workload. CockroachDB's **follower reads** let sufficiently old
+reads be served by the nearest replica instead, reducing impact on the live
+workload and cross-region latency. crdb-dump already supports pinned
+`--as-of-system-time`; this adds a convenient way to read at a
+follower-read-eligible timestamp.
+
+## Goal
+
+Add `--as-of-system-time=follower`, which pins `follower_read_timestamp()` once and
+reuses it for the whole export, so data is read from followers while keeping the
+existing cross-table consistency guarantee.
+
+## Decisions (from brainstorming, approved)
+
+- **Surface:** reuse the existing option as a resolved keyword
+  `--as-of-system-time=follower` (mirrors `auto`). No separate flag.
+- **Transaction model:** keep the existing **AUTOCOMMIT** reads at the pinned
+  timestamp (do NOT switch to explicit `PRIORITY HIGH` transactions).
+  - Consistency comes from the pinned timestamp, not transaction grouping, so
+    AUTOCOMMIT statements at one fixed `T` are fully consistent.
+  - AUTOCOMMIT avoids long-running transactions, which a chunked export would
+    otherwise create (a read txn held open across all chunks + file I/O).
+  - Follower routing depends only on the read timestamp ≤ the range's closed
+    timestamp, not on transaction structure, so AUTOCOMMIT reads are still served
+    by followers.
+  - Accepted tradeoff: an exact-staleness read may occasionally wait on an
+    unresolved write intent. `PRIORITY HIGH` would avoid that but can push/abort
+    foreground writers — counter to a low-impact export — so it is intentionally
+    not used. A future opt-in `--priority` could add it.
+
+## Architecture
+
+### Resolution (`crdb_dump/export/data.py`, `export_data`)
+
+Extend the existing pin-once block with one branch:
+
+```python
+aost = opts.get("aost")
+if aost == "auto":
+    with engine.connect() as conn:
+        aost = str(conn.execute(text("SELECT cluster_logical_timestamp()")).scalar())
+elif aost == "follower":
+    try:
+        with engine.connect() as conn:
+            aost = str(conn.execute(text("SELECT follower_read_timestamp()")).scalar())
+    except Exception as e:
+        raise click.UsageError(
+            "Follower reads are not available on this cluster "
+            "(requires a CockroachDB entitlement that enables follower reads): "
+            f"{e}")
+if aost is not None:
+    logger.info(f"🕒 Pinned AS OF SYSTEM TIME {aost}")
+opts["aost_resolved"] = aost
+```
+
+`click` is imported in `data.py` for `UsageError` (add the import).
+The resolved decimal flows through the existing `aost_clause()` + AUTOCOMMIT path
+unchanged; the manifest's `as_of_system_time` records it as before.
+
+### CLI help (`crdb_dump/cli.py`)
+
+Update the `--as-of-system-time` help to mention `follower`:
+
+> "Read data at a consistent snapshot. Use `auto` (or the bare flag) to pin
+> `cluster_logical_timestamp()`, `follower` to pin `follower_read_timestamp()`
+> for follower reads, or pass an explicit interval/timestamp/decimal."
+
+### Error handling
+
+`follower_read_timestamp()` raises if the cluster lacks the follower-reads
+entitlement. We catch this at resolution time (before exporting any table) and
+raise a `click.UsageError` with a clear message — never a raw traceback, and never
+a silent fall-back to leaseholder reads.
+
+## Verification of follower routing
+
+Because "it's served by a follower" is the whole value proposition, the spec
+requires empirical confirmation (not just that the export succeeds):
+
+- Run `EXPLAIN ANALYZE SELECT ... AS OF SYSTEM TIME '<pinned>'` against a table
+  and confirm the plan reports `used follower read`. This is done during
+  implementation against a live cluster and captured as an integration check
+  where the cluster supports it.
+
+## Testing (all three levels, entitlement-tolerant)
+
+- **Unit** (`tests/test_data_export.py` or `tests/test_aost.py`): with a mocked
+  engine whose `SELECT follower_read_timestamp()` returns a value, calling
+  `export_data` with `opts["aost"]="follower"` sets `opts["aost_resolved"]` to that
+  value; and when the mock raises, a `click.UsageError` is raised.
+- **Integration** (`tests/test_integration.py`, gated on `CRDB_URL`): run
+  `export --as-of-system-time=follower`; assert **either** success with a recorded
+  `as_of_system_time` **or** a clean `UsageError`-style message (exit_code != 0,
+  no traceback) if the cluster lacks the entitlement. Where follower reads are
+  available, also assert `EXPLAIN ANALYZE` shows `used follower read`.
+- **E2E** (`test-local.sh`): add a follower step that runs the export and accepts
+  either outcome (success with manifest timestamp, or the clean "not available"
+  message), so the script passes on an insecure single-node cluster regardless of
+  entitlement.
+
+Empirical pre-check during implementation: determine whether
+`follower_read_timestamp()` works on a local insecure single-node v25.4 (the 2024
+licensing changes may allow it); shape the integration/e2e assertions accordingly.
+
+## Docs
+
+- `docs/guides/export-data.md`: document `--as-of-system-time=follower` under the
+  consistent-snapshots section, including the entitlement requirement and the
+  low-impact (default priority) tradeoff.
+- `docs/guides/region-aware.md` (or migration-limitations): cross-link follower
+  reads as a low-impact export option for multi-region clusters.
+- `CHANGELOG.md`: under `Unreleased` → Added.
+
+## Out of scope
+
+- Bounded-staleness reads (`with_max_staleness(...)`): use a dynamic per-statement
+  timestamp, incompatible with the pin-once consistency model.
+- `PRIORITY HIGH` / explicit-transaction reads (possible future `--priority` opt-in).
+- Strong follower reads for `GLOBAL` tables (automatic; nothing to add).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crdb-dump"
-version = "0.5.0"
+version = "0.6.0"
 description = "A CLI tool to export and import schema definitions and data from CockroachDB in SQL, JSON, YAML, or chunked CSV formats."
 
 authors = [

--- a/test-local.sh
+++ b/test-local.sh
@@ -192,6 +192,19 @@ assert m.get("as_of_system_time"), "manifest missing as_of_system_time"
 print("✅ AOST timestamp recorded:", m["as_of_system_time"])
 PY
 
+echo "🛰️  Testing --as-of-system-time=follower (tolerant of entitlement)..."
+if $CRDB_DUMP --verbose export --db="$DB_NAME" --tables=public.users \
+     --data --data-format=csv --as-of-system-time=follower \
+     --out-dir="$OUT_DIR/follower" 2>"$OUT_DIR/follower.err"; then
+  echo "✅ follower-read export succeeded"
+else
+  if grep -q "Follower reads are not available" "$OUT_DIR/follower.err"; then
+    echo "ℹ️  follower reads not entitled on this cluster — clean error, OK"
+  else
+    echo "❌ unexpected follower-read failure:"; cat "$OUT_DIR/follower.err"; exit 1
+  fi
+fi
+
 echo "🧪 Verifying chunks..."
 $CRDB_DUMP --verbose export \
   --db="$DB_NAME" \

--- a/test-local.sh
+++ b/test-local.sh
@@ -45,6 +45,16 @@ DATA_DIR="$BASE_OUT_DIR"
 LOG_FILE="logs/crdb_dump.log"
 RESUME_FILE="$OUT_DIR/resume.json"
 
+# This is a LOCAL end-to-end harness: setup uses `cockroach sql --host=localhost`,
+# but crdb-dump honors $CRDB_URL. If an external CRDB_URL is inherited (e.g. a
+# Cloud cluster), crdb-dump would target a DIFFERENT cluster than the setup — and
+# could run destructive load/drop steps against it. Pin CRDB_URL to the local
+# cluster so everything targets the same place. (Not the password — never echoed.)
+if [ -n "${CRDB_URL:-}" ]; then
+  echo "⚠️  An external CRDB_URL is set; overriding it to the local cluster for this run."
+fi
+export CRDB_URL="cockroachdb://root@localhost:26257/${DB_NAME}?sslmode=disable"
+
 echo "🚀 Ensuring MinIO is running..."
 
 MINIO_CONTAINER="crdb-minio"

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -63,3 +63,39 @@ def test_export_table_data_records_aost(tmp_path):
     manifest = json.load(open(tmp_path / "cp.cpkit.tasks.manifest.json"))
     assert manifest["as_of_system_time"] == "1750.0"
     assert any("AS OF SYSTEM TIME '1750.0'" in s for s in captured["stmts"])
+
+
+def _engine_returning_scalar(value=None, raises=None):
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    if raises is not None:
+        conn.execute.side_effect = raises
+    else:
+        conn.execute.return_value = MagicMock(scalar=lambda: value)
+    engine = MagicMock()
+    engine.connect.return_value = conn
+    return engine
+
+
+def test_export_data_resolves_follower(monkeypatch, tmp_path):
+    engine = _engine_returning_scalar(value="1750.5")
+    monkeypatch.setattr(data_mod, "get_sqlalchemy_engine", lambda opts: engine)
+    monkeypatch.setattr(data_mod, "get_table_locality", lambda e, db, lg: {})
+    monkeypatch.setattr(data_mod, "collect_objects", lambda *a, **k: [])
+    opts = {"db": "d", "tables": None, "aost": "follower", "region": None,
+            "data_parallel": False, "retry_count": 1, "retry_delay": 0}
+    data_mod.export_data(opts, str(tmp_path), logging.getLogger("t"))
+    assert opts["aost_resolved"] == "1750.5"
+
+
+def test_export_data_follower_unavailable_raises(monkeypatch, tmp_path):
+    import click
+    import pytest
+    engine = _engine_returning_scalar(raises=Exception("requires enterprise"))
+    monkeypatch.setattr(data_mod, "get_sqlalchemy_engine", lambda opts: engine)
+    monkeypatch.setattr(data_mod, "get_table_locality", lambda e, db, lg: {})
+    opts = {"db": "d", "tables": None, "aost": "follower", "region": None,
+            "data_parallel": False, "retry_count": 1, "retry_delay": 0}
+    with pytest.raises(click.UsageError):
+        data_mod.export_data(opts, str(tmp_path), logging.getLogger("t"))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -292,8 +292,8 @@ def test_aost_follower_keyword(tmp_path):
     cur.execute("INSERT INTO fr_t VALUES (1), (2)")
     cur.close()
     conn.close()
-    # follower_read_timestamp() is ~4.2s in the past; wait so the table and rows
-    # already exist at that timestamp (otherwise the read sees no such table).
+    # follower_read_timestamp() reads slightly in the past; wait so the table and
+    # rows already exist at that timestamp (otherwise the read sees no such table).
     time.sleep(6)
 
     out = tmp_path / "out"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -278,3 +278,31 @@ def test_aost_bare_flag_pins_timestamp(tmp_path):
     import json
     manifest = json.load(open(out / "defaultdb" / "defaultdb.public.aost_b.manifest.json"))
     assert manifest["as_of_system_time"]  # populated with a pinned timestamp
+
+
+@pytest.mark.integration
+@pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
+def test_aost_follower_keyword(tmp_path):
+    conn = get_psycopg_connection()
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS fr_t")
+    cur.execute("CREATE TABLE fr_t (id INT PRIMARY KEY)")
+    cur.execute("INSERT INTO fr_t VALUES (1), (2)")
+    cur.close()
+    conn.close()
+
+    out = tmp_path / "out"
+    r = CliRunner().invoke(main, [
+        "export", "--db=defaultdb", "--tables=public.fr_t",
+        "--data", "--data-format=csv", "--as-of-system-time=follower",
+        f"--out-dir={out}"])
+
+    if r.exit_code == 0:
+        import json
+        manifest = json.load(open(out / "defaultdb" / "defaultdb.public.fr_t.manifest.json"))
+        assert manifest["as_of_system_time"]  # a pinned follower timestamp
+    else:
+        # Cluster lacks the follower-reads entitlement: must be a clean message.
+        assert "Follower reads are not available" in r.output
+        assert "Traceback" not in r.output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -283,6 +283,7 @@ def test_aost_bare_flag_pins_timestamp(tmp_path):
 @pytest.mark.integration
 @pytest.mark.skipif("CRDB_URL" not in os.environ, reason="CRDB_URL must be set")
 def test_aost_follower_keyword(tmp_path):
+    import time
     conn = get_psycopg_connection()
     conn.autocommit = True
     cur = conn.cursor()
@@ -291,6 +292,9 @@ def test_aost_follower_keyword(tmp_path):
     cur.execute("INSERT INTO fr_t VALUES (1), (2)")
     cur.close()
     conn.close()
+    # follower_read_timestamp() is ~4.2s in the past; wait so the table and rows
+    # already exist at that timestamp (otherwise the read sees no such table).
+    time.sleep(6)
 
     out = tmp_path / "out"
     r = CliRunner().invoke(main, [


### PR DESCRIPTION
## Summary

Adds `--as-of-system-time=follower` to `export`: pins `follower_read_timestamp()` once so the whole export is served by the **nearest replica** (follower reads), reducing impact on the live workload and cross-region latency — while keeping the cross-table consistency guarantee.

- **Keyword** resolved like `auto`: bare `--as-of-system-time` → `cluster_logical_timestamp()`; `=follower` → `follower_read_timestamp()`; explicit value → verbatim.
- **AUTOCOMMIT at the pinned timestamp** (default priority). Consistency comes from the pinned timestamp, not transaction grouping; AUTOCOMMIT avoids long-running transactions over a chunked export; follower routing depends on the read timestamp, not txn structure. `PRIORITY HIGH` is intentionally not used (it would disrupt foreground writers).
- **Resolved via `follower_read_timestamp()::STRING`** — the raw timestamptz gets reformatted by the driver to `+00:00` (rejected by AOST) and `::DECIMAL` is in seconds (AOST decimals are nanoseconds); CRDB's native timestamp string is what AOST accepts.
- **Fails fast** with a clear `UsageError` if the cluster lacks the follower-reads entitlement — no traceback, no silent leaseholder fallback.

## Verification

- **Unit:** resolution maps `follower` → pinned value; unavailable → `UsageError`.
- **Integration (local + real Cloud cluster):** follower export succeeds and records the pinned timestamp; deterministic (waits so the table predates the follower timestamp).
- **Routing proven on a multi-node Cloud cluster:** `EXPLAIN ANALYZE … AS OF SYSTEM TIME follower_read_timestamp()` reports `used follower read` (region `gcp-us-east1`). A single node can't demonstrate this.
- **E2E:** `test-local.sh` adds a follower step tolerant of clusters without the entitlement.
- Full suite green; `mkdocs build --strict` clean.

## Notes

- `follower_read_timestamp()` reads slightly in the past, so objects created in the last few seconds aren't visible at that timestamp (non-issue for normal exports). Docs link to CockroachDB's follower-reads and `gc.ttlseconds` pages rather than hardcoding version-specific numbers.